### PR TITLE
Add sentiment analysis service with sector ETF support

### DIFF
--- a/server/routes/sentimentRoutes.ts
+++ b/server/routes/sentimentRoutes.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
 import { marketSentimentService } from '../services/marketSentimentService';
+import { sentimentAnalysisService } from '../services/sentimentAnalysis';
+import { gexTracker } from '../services/gexTracker';
 
 const router = Router();
 
@@ -26,6 +28,76 @@ router.get('/trump-alerts', async (req, res) => {
     console.error('Error fetching Trump alerts:', error);
     res.status(500).json({ 
       error: 'Failed to fetch Trump alerts',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
+
+// Get ticker-specific sentiment
+router.get('/ticker/:symbol', async (req, res) => {
+  try {
+    const data = await sentimentAnalysisService.getTickerSentiment(req.params.symbol);
+    res.json(data);
+  } catch (error) {
+    console.error('Error fetching ticker sentiment:', error);
+    res.status(500).json({
+      error: 'Failed to fetch ticker sentiment',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
+
+// Get market sentiment using SPY as proxy
+router.get('/market-proxy', async (_req, res) => {
+  try {
+    const data = await sentimentAnalysisService.getMarketSentiment();
+    res.json(data);
+  } catch (error) {
+    console.error('Error fetching market sentiment proxy:', error);
+    res.status(500).json({
+      error: 'Failed to fetch market sentiment proxy',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
+
+// Get market sentiment using direct market tide data
+router.get('/market-tide', async (_req, res) => {
+  try {
+    const data = await sentimentAnalysisService.getMarketSentimentDirect();
+    res.json(data);
+  } catch (error) {
+    console.error('Error fetching market tide:', error);
+    res.status(500).json({
+      error: 'Failed to fetch market tide',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
+
+// Get sector sentiment using sector ETF proxy
+router.get('/sector/:sector', async (req, res) => {
+  try {
+    const data = await sentimentAnalysisService.getSectorSentiment(req.params.sector);
+    res.json(data);
+  } catch (error) {
+    console.error('Error fetching sector sentiment:', error);
+    res.status(500).json({
+      error: 'Failed to fetch sector sentiment',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
+
+// Get sentiment for all watchlist tickers
+router.get('/watchlist', async (_req, res) => {
+  try {
+    await gexTracker.refreshSentiments();
+    res.json(gexTracker.getWatchlistSentiments());
+  } catch (error) {
+    console.error('Error fetching watchlist sentiment:', error);
+    res.status(500).json({
+      error: 'Failed to fetch watchlist sentiment',
       message: error instanceof Error ? error.message : 'Unknown error'
     });
   }

--- a/server/services/sentimentAnalysis.ts
+++ b/server/services/sentimentAnalysis.ts
@@ -1,0 +1,161 @@
+import { ibkrService } from './ibkr';
+import { UnusualWhalesService } from './unusualWhales';
+
+export interface SentimentWeights {
+  flow: number;
+  news: number;
+  analyst: number;
+}
+
+const DEFAULT_WEIGHTS: SentimentWeights = {
+  flow: 0.5,
+  news: 0.3,
+  analyst: 0.2,
+};
+
+export interface TickerSentimentResult {
+  ticker: string;
+  ticker_sentiment: number;
+  component_scores: {
+    news_score: number;
+    analyst_score: number;
+    flow_score: number;
+  };
+  raw: {
+    news: any[];
+    analyst_ratings: any[];
+    options_flow: any[];
+    market_data: any;
+  };
+}
+
+export class SentimentAnalysisService {
+  private uw: UnusualWhalesService;
+
+  constructor() {
+    this.uw = new UnusualWhalesService();
+  }
+
+  async getTickerSentiment(ticker: string, weights: Partial<SentimentWeights> = {}): Promise<TickerSentimentResult> {
+    const w = { ...DEFAULT_WEIGHTS, ...weights };
+
+    const [news, analysts, flow] = await Promise.all([
+      this.uw.getNewsSentiment(ticker),
+      this.uw.getAnalystRatings(ticker),
+      this.uw.getOptionsFlow(ticker),
+    ]);
+
+    let marketData: any = null;
+    try {
+      if (!ibkrService.isConnected()) {
+        await ibkrService.connect();
+      }
+      marketData = await ibkrService.getMarketData(ticker);
+    } catch (error) {
+      console.error('Failed to fetch IBKR market data:', error);
+    }
+
+    const newsScore = this.calculateNewsScore(news);
+    const analystScore = this.calculateAnalystScore(analysts);
+    const flowScore = this.calculateFlowScore(flow);
+
+    const totalWeight = w.flow + w.news + w.analyst;
+    const sentiment =
+      totalWeight === 0
+        ? 0
+        : (flowScore * w.flow + newsScore * w.news + analystScore * w.analyst) /
+          totalWeight;
+
+    return {
+      ticker: ticker.toUpperCase(),
+      ticker_sentiment: sentiment,
+      component_scores: {
+        news_score: newsScore,
+        analyst_score: analystScore,
+        flow_score: flowScore,
+      },
+      raw: {
+        news,
+        analyst_ratings: analysts,
+        options_flow: flow,
+        market_data: marketData,
+      },
+    };
+  }
+
+  async getMarketSentiment(weights: Partial<SentimentWeights> = {}): Promise<TickerSentimentResult> {
+    return this.getTickerSentiment('SPY', weights);
+  }
+
+  async getMarketSentimentDirect(): Promise<{ market_sentiment: number; raw: any } | null> {
+    try {
+      const data = await this.uw.getMarketTide();
+      if (!data) return null;
+      const bullish = Number(data?.bullish_premium) || 0;
+      const bearish = Number(data?.bearish_premium) || 0;
+      const score = bullish + bearish === 0 ? 0 : (bullish - bearish) / (bullish + bearish);
+      return { market_sentiment: score, raw: data };
+    } catch (error) {
+      console.error('Failed to fetch market tide data:', error);
+      return null;
+    }
+  }
+
+  async getSectorSentiment(sectorOrEtf: string, weights: Partial<SentimentWeights> = {}): Promise<TickerSentimentResult> {
+    const etf = this.sectorEtfMap[sectorOrEtf.toLowerCase()] || sectorOrEtf;
+    return this.getTickerSentiment(etf, weights);
+  }
+
+  private sectorEtfMap: Record<string, string> = {
+    technology: 'XLK',
+    financials: 'XLF',
+    energy: 'XLE',
+    healthcare: 'XLV',
+    industrials: 'XLI',
+    materials: 'XLB',
+    utilities: 'XLU',
+    realestate: 'XLRE',
+    consumerdiscretionary: 'XLY',
+    consumercyclicals: 'XLY',
+    consumerstaples: 'XLP',
+    communicationservices: 'XLC',
+  };
+
+  private calculateNewsScore(news: any[]): number {
+    if (!news.length) return 0;
+    let total = 0;
+    news.forEach((article) => {
+      const sentiment = (article.sentiment || article.label || '').toLowerCase();
+      if (sentiment === 'bullish') total += 1;
+      else if (sentiment === 'bearish') total -= 1;
+    });
+    return total / news.length;
+  }
+
+  private calculateAnalystScore(ratings: any[]): number {
+    if (!ratings.length) return 0;
+    let total = 0;
+    ratings.forEach((r) => {
+      const rating = (r.rating || r.recommendation || '').toLowerCase();
+      if (['buy', 'overweight', 'strong buy'].includes(rating)) total += 1;
+      else if (['sell', 'underweight', 'strong sell'].includes(rating)) total -= 1;
+    });
+    return total / ratings.length;
+  }
+
+  private calculateFlowScore(flows: any[]): number {
+    if (!flows.length) return 0;
+    let bullish = 0;
+    let bearish = 0;
+    flows.forEach((t) => {
+      const premium = Number(t.premium || t.total_premium || 0);
+      const sentiment = (t.sentiment || t.flag || '').toLowerCase();
+      if (sentiment === 'bullish') bullish += premium;
+      else if (sentiment === 'bearish') bearish += premium;
+    });
+    if (bullish + bearish === 0) return 0;
+    return (bullish - bearish) / (bullish + bearish);
+  }
+}
+
+export const sentimentAnalysisService = new SentimentAnalysisService();

--- a/server/services/unusualWhales.ts
+++ b/server/services/unusualWhales.ts
@@ -216,6 +216,45 @@ export class UnusualWhalesService {
     }
   }
 
+  async getNewsSentiment(ticker: string): Promise<any[]> {
+    try {
+      const data = await this.makeRequest<{ data: any[] }>(`/news-sentiment/${ticker}`);
+      return data.data || [];
+    } catch (error) {
+      console.error(`Failed to fetch news sentiment for ${ticker}:`, error);
+      return [];
+    }
+  }
+
+  async getAnalystRatings(ticker: string): Promise<any[]> {
+    try {
+      const data = await this.makeRequest<{ data: any[] }>(`/analysts/ratings/${ticker}`);
+      return data.data || [];
+    } catch (error) {
+      console.error(`Failed to fetch analyst ratings for ${ticker}:`, error);
+      return [];
+    }
+  }
+
+  async getOptionsFlow(ticker: string): Promise<any[]> {
+    try {
+      const data = await this.makeRequest<{ data: any[] }>(`/options/flow/${ticker}`);
+      return data.data || [];
+    } catch (error) {
+      console.error(`Failed to fetch options flow for ${ticker}:`, error);
+      return [];
+    }
+  }
+
+  async getMarketTide(): Promise<any | null> {
+    try {
+      return await this.makeRequest<any>(`/market-tide/`);
+    } catch (error) {
+      console.error('Failed to fetch market tide data:', error);
+      return null;
+    }
+  }
+
   async getCustomAlerts(): Promise<any[]> {
     try {
       const data = await this.makeRequest<{ data: any[] }>('/alerts');
@@ -237,12 +276,8 @@ export class UnusualWhalesService {
   async getGammaExposure(symbol: string): Promise<any> {
     try {
       console.log(`Fetching gamma exposure data for ${symbol}...`);
-      
-      const response = await this.makeRequest('/gamma-exposure', {
-        symbol: symbol.toUpperCase()
-      });
-
-      return (response as any).data || [];
+      const response = await this.makeRequest<{ data: any[] }>(`/gamma-exposure?symbol=${symbol.toUpperCase()}`);
+      return response.data || [];
     } catch (error) {
       console.error(`Failed to fetch gamma exposure for ${symbol}:`, error);
       throw error;


### PR DESCRIPTION
## Summary
- Add `SentimentAnalysisService` to compute ticker, market, and sector sentiment using Unusual Whales and IBKR APIs, with configurable weights and sector ETF mapping.
- Extend `UnusualWhalesService` with public helpers for news sentiment, analyst ratings, options flow, market tide, and update gamma exposure request format.
- Expose new `/ticker`, `/market-proxy`, `/market-tide`, `/sector`, and `/watchlist` endpoints through sentiment routes.
- Update GEX tracker to refresh and store sentiment for watchlist tickers as part of its scheduled updates.

## Testing
- `npm run check` *(fails: Parameter 'trade' implicitly has an 'any' type. ...)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e41961b10832086b4a41e08d83379