### PR TITLE
Add earnings-based earnings options screener

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Development Environment Variables
+# Copy this to .env and fill in your actual values
+
+# Database Configuration (for local development)
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/uwibkr_dev"
+
+# API Keys
+UNUSUAL_WHALES_API_KEY="your_unusual_whales_api_key_here"
+
+# Optional: Other environment variables
+NODE_ENV="development"
+PORT="3000"
+
+# For production, use your Neon database URL:
+# DATABASE_URL="postgresql://username:password@your-neon-db-url/database"

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -1,0 +1,183 @@
+# UWIBKR Local Development Setup
+
+## Prerequisites
+
+1. **WSL2** (Windows Subsystem for Linux)
+2. **Docker** and **Docker Compose**
+3. **Node.js** (v18 or higher)
+4. **npm** or **yarn**
+
+## Quick Setup
+
+### 1. Clone and Setup
+```bash
+# If you haven't already, navigate to your project directory
+cd /path/to/UWIBKR
+
+# Make setup script executable and run it
+chmod +x setup-dev.sh
+./setup-dev.sh
+```
+
+### 2. Configure Environment Variables
+Edit the `.env` file and add your API keys:
+```bash
+nano .env
+```
+
+Required variables:
+```env
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/uwibkr_dev"
+UNUSUAL_WHALES_API_KEY="your_actual_api_key_here"
+```
+
+### 3. Start Development
+```bash
+# Start the development server
+npm run dev
+```
+
+## Manual Setup Steps
+
+If you prefer to set up manually:
+
+### 1. Database Setup with Docker
+```bash
+# Start PostgreSQL database
+docker-compose up -d postgres
+
+# Wait for database to be ready
+docker-compose exec postgres pg_isready -U postgres
+
+# Run database migrations
+npm run db:push
+```
+
+### 2. Alternative: Install PostgreSQL Directly
+```bash
+# Update package list
+sudo apt update
+
+# Install PostgreSQL
+sudo apt install postgresql postgresql-contrib
+
+# Start PostgreSQL service
+sudo service postgresql start
+
+# Create database and user
+sudo -u postgres psql
+```
+
+In PostgreSQL prompt:
+```sql
+CREATE DATABASE uwibkr_dev;
+CREATE USER postgres WITH PASSWORD 'postgres';
+GRANT ALL PRIVILEGES ON DATABASE uwibkr_dev TO postgres;
+\q
+```
+
+## Testing the Earnings Screener
+
+### 1. Start the Server
+```bash
+npm run dev
+```
+
+### 2. Test Endpoints
+
+**Health Check:**
+```bash
+curl http://localhost:3000/api/system/health
+```
+
+**Earnings Screener (Basic):**
+```bash
+curl "http://localhost:3000/api/earnings-screener"
+```
+
+**Earnings Screener (With Parameters):**
+```bash
+curl "http://localhost:3000/api/earnings-screener?days=3&minVolume=500&minIvPercent=75&minLargeTrades=3"
+```
+
+### 3. Automated Testing
+```bash
+# Make test script executable and run
+chmod +x test-earnings-screener.sh
+./test-earnings-screener.sh
+```
+
+## Available Parameters
+
+The earnings screener endpoint accepts these query parameters:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `days` | 5 | Days ahead to look for earnings |
+| `minVolume` | 1000 | Minimum options volume |
+| `minLargeTrades` | 5 | Minimum number of large trades |
+| `largeTradePremium` | 50000 | Minimum premium for "large" trades |
+| `volumeMultiplier` | 3 | Volume multiplier vs 30-day average |
+| `minIvPercent` | 90 | Minimum implied volatility percentage |
+| `bearishRatio` | 2 | Put/call ratio threshold for bearish signals |
+| `bullishRatio` | 0.5 | Put/call ratio threshold for bullish signals |
+
+## Database Management
+
+```bash
+# Start database
+npm run dev:db
+
+# Stop database
+npm run db:stop
+
+# Reset database (deletes all data)
+npm run db:reset
+
+# Push schema changes
+npm run db:push
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Database Connection Error**
+   - Ensure PostgreSQL is running: `docker-compose ps`
+   - Check connection string in `.env`
+
+2. **API Key Issues**
+   - Verify `UNUSUAL_WHALES_API_KEY` is set in `.env`
+   - Test API key with: `curl -H "Authorization: Bearer YOUR_KEY" https://api.unusualwhales.com/api/reference/earnings_calendar`
+
+3. **Port Already in Use**
+   - Change port in `.env`: `PORT=3001`
+   - Or kill existing process: `sudo lsof -t -i tcp:3000 | xargs kill -9`
+
+### Logs and Debugging
+
+```bash
+# View application logs
+npm run dev
+
+# View database logs
+docker-compose logs postgres
+
+# View all containers
+docker-compose ps
+```
+
+## Project Structure
+
+```
+UWIBKR/
+├── server/
+│   ├── routes/
+│   │   └── earningsScreener.ts  # Main earnings screener logic
+│   ├── index.ts                 # Server entry point
+│   └── routes.ts               # Route registration
+├── docker-compose.yml          # Database setup
+├── setup-dev.sh               # Automated setup script
+├── test-earnings-screener.sh   # Test script
+└── .env.example               # Environment template
+```

--- a/WSL2_SETUP_NO_DOCKER.md
+++ b/WSL2_SETUP_NO_DOCKER.md
@@ -33,11 +33,38 @@ PORT="3000"
 npm run dev
 ```
 
+### 4. Access the GUI
+After starting the development server, open your web browser and go to:
+```
+http://localhost:3000
+```
+
+The GUI will be available at this URL. If port 3000 is already in use, check your `.env` file for a different PORT setting.
+
 ## ⚠️ Important Notes
 
 - **Always use WSL2 terminal** for all commands
 - **Don't run from Windows PowerShell** - native modules are Linux-specific
 - Access your project at: `cd /mnt/c/Users/mjhen/UWIBKR/UWIBKR`
+
+## How to Start the GUI
+
+1. **Open WSL2 Terminal** (Ubuntu/WSL2, NOT Windows PowerShell)
+2. **Navigate to project:**
+   ```bash
+   cd /mnt/c/Users/mjhen/UWIBKR/UWIBKR
+   ```
+3. **Start PostgreSQL:**
+   ```bash
+   sudo service postgresql start
+   ```
+4. **Start the development server:**
+   ```bash
+   npm run dev
+   ```
+5. **Open your browser and go to:** `http://localhost:3000`
+
+**Important:** The server must be running in WSL2 for the GUI to work properly.
 
 ## Manual Installation Steps
 
@@ -137,18 +164,24 @@ psql -h localhost -U postgres -d uwibkr_dev
 
 ### Common Issues
 
-1. **"Connection refused" error**
+1. **GUI not loading / "This site can't be reached" error**
+   - Make sure you're running `npm run dev` in WSL2, not Windows PowerShell
+   - Check if the server is actually running: look for "serving on port 3000" message
+   - Verify the port in your browser URL matches the PORT in your `.env` file
+   - Try accessing `http://127.0.0.1:3000` instead of `localhost:3000`
+
+2. **"Connection refused" error**
    - PostgreSQL not running: `sudo service postgresql start`
    - Wrong connection string in `.env`
 
-2. **"Authentication failed" error**
+3. **"Authentication failed" error**
    - Check password in `.env` matches what you set
    - Reset password: `sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"`
 
-3. **"Database does not exist" error**
+4. **"Database does not exist" error**
    - Create database: `sudo -u postgres createdb uwibkr_dev`
 
-4. **Port 3000 already in use**
+5. **Port 3000 already in use**
    - Change port in `.env`: `PORT=3001`
    - Kill existing process: `sudo lsof -t -i tcp:3000 | xargs kill -9`
 

--- a/WSL2_SETUP_NO_DOCKER.md
+++ b/WSL2_SETUP_NO_DOCKER.md
@@ -1,0 +1,185 @@
+# UWIBKR WSL2 Setup Guide (No Docker)
+
+## Quick Setup
+
+Since Docker Desktop integration isn't working, we'll use native PostgreSQL:
+
+### 1. Run the Setup Script
+```bash
+# Make setup script executable and run it
+chmod +x setup-dev-no-docker.sh
+./setup-dev-no-docker.sh
+```
+
+### 2. Configure Environment Variables
+```bash
+# Edit the .env file
+nano .env
+```
+
+Make sure it contains:
+```env
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/uwibkr_dev"
+UNUSUAL_WHALES_API_KEY="your_actual_api_key_here"
+NODE_ENV="development"
+PORT="3000"
+```
+
+### 3. Start Development
+```bash
+# Start the development server
+npm run dev
+```
+
+## Manual Installation Steps
+
+If the script fails, follow these manual steps:
+
+### 1. Install PostgreSQL
+```bash
+# Update package list
+sudo apt update
+
+# Install PostgreSQL
+sudo apt install -y postgresql postgresql-contrib
+
+# Start PostgreSQL
+sudo service postgresql start
+```
+
+### 2. Configure Database
+```bash
+# Connect as postgres user and setup database
+sudo -u postgres psql
+```
+
+In PostgreSQL prompt:
+```sql
+ALTER USER postgres PASSWORD 'postgres';
+CREATE DATABASE uwibkr_dev;
+GRANT ALL PRIVILEGES ON DATABASE uwibkr_dev TO postgres;
+\q
+```
+
+### 3. Install Node Dependencies
+```bash
+npm install
+```
+
+### 4. Run Database Migrations
+```bash
+npm run db:push
+```
+
+## Testing
+
+### 1. Start Services
+```bash
+# Start PostgreSQL (if not running)
+sudo service postgresql start
+
+# Start development server (in another terminal)
+npm run dev
+```
+
+### 2. Test the API
+```bash
+# Make test script executable
+chmod +x test-earnings-screener.sh
+
+# Run tests
+./test-earnings-screener.sh
+```
+
+### 3. Manual API Tests
+```bash
+# Health check
+curl http://localhost:3000/api/system/health
+
+# Basic earnings screener test
+curl "http://localhost:3000/api/earnings-screener"
+
+# With parameters
+curl "http://localhost:3000/api/earnings-screener?days=3&minVolume=500"
+```
+
+## Troubleshooting
+
+### PostgreSQL Issues
+
+**Check if PostgreSQL is running:**
+```bash
+sudo service postgresql status
+```
+
+**Start PostgreSQL:**
+```bash
+sudo service postgresql start
+```
+
+**Check PostgreSQL logs:**
+```bash
+sudo tail -f /var/log/postgresql/postgresql-*-main.log
+```
+
+**Connect to database manually:**
+```bash
+psql -h localhost -U postgres -d uwibkr_dev
+```
+
+### Common Issues
+
+1. **"Connection refused" error**
+   - PostgreSQL not running: `sudo service postgresql start`
+   - Wrong connection string in `.env`
+
+2. **"Authentication failed" error**
+   - Check password in `.env` matches what you set
+   - Reset password: `sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"`
+
+3. **"Database does not exist" error**
+   - Create database: `sudo -u postgres createdb uwibkr_dev`
+
+4. **Port 3000 already in use**
+   - Change port in `.env`: `PORT=3001`
+   - Kill existing process: `sudo lsof -t -i tcp:3000 | xargs kill -9`
+
+### Environment Variables Check
+```bash
+# Check if .env is loaded
+node -e "require('dotenv').config(); console.log(process.env.DATABASE_URL);"
+```
+
+## Database Management Commands
+
+```bash
+# Start PostgreSQL
+npm run dev:db
+
+# Stop PostgreSQL
+npm run db:stop
+
+# Check status
+npm run db:status
+
+# Reset database (careful - deletes all data!)
+npm run db:reset
+
+# Connect to database
+psql postgresql://postgres:postgres@localhost:5432/uwibkr_dev
+```
+
+## Setting Up Docker (Optional)
+
+If you want to fix Docker Desktop integration later:
+
+1. **Open Docker Desktop on Windows**
+2. **Settings → Resources → WSL Integration**
+3. **Enable integration with your Ubuntu distro**
+4. **Restart Docker Desktop and WSL2**
+5. **Test**: `docker --version` and `docker-compose --version`
+
+Once Docker works, you can use:
+```bash
+npm run dev:setup-docker
+```

--- a/WSL2_SETUP_NO_DOCKER.md
+++ b/WSL2_SETUP_NO_DOCKER.md
@@ -1,5 +1,7 @@
 # UWIBKR WSL2 Setup Guide (No Docker)
 
+⚠️ **Important**: Always run commands inside WSL2, not Windows PowerShell/CMD. The project uses native modules that are Linux-specific.
+
 ## Quick Setup
 
 Since Docker Desktop integration isn't working, we'll use native PostgreSQL:
@@ -27,9 +29,15 @@ PORT="3000"
 
 ### 3. Start Development
 ```bash
-# Start the development server
+# ALWAYS run this in WSL2, not Windows PowerShell
 npm run dev
 ```
+
+## ⚠️ Important Notes
+
+- **Always use WSL2 terminal** for all commands
+- **Don't run from Windows PowerShell** - native modules are Linux-specific
+- Access your project at: `cd /mnt/c/Users/mjhen/UWIBKR/UWIBKR`
 
 ## Manual Installation Steps
 

--- a/check-env.sh
+++ b/check-env.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+echo "🔍 Checking environment variables..."
+
+# Check if .env file exists
+if [ ! -f .env ]; then
+    echo "❌ .env file not found!"
+    echo "📝 Creating .env from template..."
+    cp .env.example .env
+    echo "⚠️  Please edit .env file and add your UNUSUAL_WHALES_API_KEY"
+    exit 1
+fi
+
+echo "✅ .env file found"
+
+# Test environment loading
+echo "🧪 Testing environment variable loading..."
+node -e "
+import 'dotenv/config';
+console.log('DATABASE_URL:', process.env.DATABASE_URL ? '✅ Set' : '❌ Not set');
+console.log('UNUSUAL_WHALES_API_KEY:', process.env.UNUSUAL_WHALES_API_KEY ? '✅ Set' : '❌ Not set');
+console.log('NODE_ENV:', process.env.NODE_ENV || 'Not set');
+console.log('PORT:', process.env.PORT || 'Not set');
+"
+
+echo ""
+echo "💡 If DATABASE_URL is not set, check your .env file format:"
+echo "   - No spaces around = sign"
+echo "   - No quotes unless needed"
+echo "   - Unix line endings (LF, not CRLF)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: uwibkr_dev
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,5 @@
+-- Initialize the database with basic setup
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Grant necessary permissions
+GRANT ALL PRIVILEGES ON DATABASE uwibkr_dev TO postgres;

--- a/install-postgresql.sh
+++ b/install-postgresql.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+echo "🐘 Installing PostgreSQL directly in WSL2..."
+
+# Update package list
+sudo apt update
+
+# Install PostgreSQL and additional contrib package
+sudo apt install -y postgresql postgresql-contrib
+
+# Start PostgreSQL service
+sudo service postgresql start
+
+# Enable PostgreSQL to start automatically
+sudo systemctl enable postgresql
+
+echo "🔧 Configuring PostgreSQL..."
+
+# Set password for postgres user and create database
+sudo -u postgres psql << EOF
+ALTER USER postgres PASSWORD 'postgres';
+CREATE DATABASE uwibkr_dev;
+GRANT ALL PRIVILEGES ON DATABASE uwibkr_dev TO postgres;
+\q
+EOF
+
+# Configure PostgreSQL to allow connections
+sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /etc/postgresql/*/main/postgresql.conf
+sudo sed -i "s/#port = 5432/port = 5432/" /etc/postgresql/*/main/postgresql.conf
+
+# Add authentication rule for local connections
+echo "host    all             all             127.0.0.1/32            md5" | sudo tee -a /etc/postgresql/*/main/pg_hba.conf
+
+# Restart PostgreSQL to apply changes
+sudo service postgresql restart
+
+echo "✅ PostgreSQL installation complete!"
+echo ""
+echo "📋 Database connection details:"
+echo "   Host: localhost"
+echo "   Port: 5432"
+echo "   Database: uwibkr_dev"
+echo "   Username: postgres"
+echo "   Password: postgres"
+echo ""
+echo "🔗 Connection string for .env:"
+echo "   DATABASE_URL=\"postgresql://postgres:postgres@localhost:5432/uwibkr_dev\""

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^17.2.1",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -5217,6 +5218,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "dotenv": "^17.2.1",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,16 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "dev:db": "docker-compose up -d postgres",
-    "dev:setup": "chmod +x setup-dev.sh && ./setup-dev.sh",
+    "dev:db": "sudo service postgresql start",
+    "dev:setup": "chmod +x setup-dev-no-docker.sh && ./setup-dev-no-docker.sh",
+    "dev:setup-docker": "chmod +x setup-dev.sh && ./setup-dev.sh",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
-    "db:stop": "docker-compose down",
-    "db:reset": "docker-compose down -v && docker-compose up -d postgres && npm run db:push"
+    "db:stop": "sudo service postgresql stop",
+    "db:status": "sudo service postgresql status",
+    "db:reset": "sudo -u postgres psql -d uwibkr_dev -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;' && npm run db:push"
   },
   "dependencies": {
     "@google/genai": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,14 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev:db": "docker-compose up -d postgres",
+    "dev:setup": "chmod +x setup-dev.sh && ./setup-dev.sh",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "db:stop": "docker-compose down",
+    "db:reset": "docker-compose down -v && docker-compose up -d postgres && npm run db:push"
   },
   "dependencies": {
     "@google/genai": "^1.12.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -8,6 +8,7 @@ import shortExpiryRoutes from "./routes/shortExpiryRoutes";
 import ordersRoutes from "./routes/orders";
 import fdaRoutes from "./routes/fdaRoutes";
 import optionsScreenerRoutes from "./routes/optionsScreener";
+import earningsScreenerRoutes from "./routes/earningsScreener";
 import { 
   insertTradingSignalSchema, 
   insertPositionSchema,
@@ -2365,6 +2366,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // Initialize routes last
   app.use('/api/options', optionsScreenerRoutes);
+  app.use('/api/options', earningsScreenerRoutes);
   
   // Options heatmap routes
   const { default: optionsHeatmapRoutes } = await import('./routes/optionsHeatmap');

--- a/server/routes/earningsScreener.ts
+++ b/server/routes/earningsScreener.ts
@@ -143,11 +143,18 @@ router.get('/earnings-screener', async (req, res) => {
       if (!chainResp.ok) continue;
       const chain = (await chainResp.json()) as ChainResponse;
 
-      const earningsDate = new Date(event.report_date || event.earnings_date);
+      let earningsDate: Date | null = null;
+      if (event.report_date && !isNaN(new Date(event.report_date).getTime())) {
+        earningsDate = new Date(event.report_date);
+      } else if (event.earnings_date && !isNaN(new Date(event.earnings_date).getTime())) {
+        earningsDate = new Date(event.earnings_date);
+      } else {
+        continue; // Skip if no valid date
+      }
       const expirations = chain.expirations ?? [];
       const targetExp = expirations
         .map((e) => new Date(e))
-        .filter((d) => d >= earningsDate)
+        .filter((d) => d >= earningsDate!)
         .sort((a, b) => a.getTime() - b.getTime())[0];
       if (!targetExp) continue;
 

--- a/server/routes/earningsScreener.ts
+++ b/server/routes/earningsScreener.ts
@@ -187,7 +187,11 @@ router.get('/earnings-screener', async (req, res) => {
     res.json({ success: true, total: candidates.length, candidates });
   } catch (err) {
     console.error('earnings screener error', err);
-    res.status(500).json({ success: false, error: 'Failed to run earnings screener' });
+    res.status(500).json({
+      success: false,
+      error: 'Failed to run earnings screener',
+      details: err instanceof Error ? { name: err.name, message: err.message } : String(err),
+    });
   }
 });
 

--- a/server/routes/earningsScreener.ts
+++ b/server/routes/earningsScreener.ts
@@ -60,17 +60,22 @@ function formatDate(date: Date): string {
 }
 
 router.get('/earnings-screener', async (req, res) => {
-  const {
-    days = '5',
-    minVolume = '1000',
-    minLargeTrades = '5',
-    largeTradePremium = '50000',
-    volumeMultiplier = '3',
-    minIvPercent = '90',
-    bearishRatio = '2',
-    bullishRatio = '0.5',
-  } = req.query as Record<string, string>;
+  // Helper to safely extract a string parameter from req.query
+  function getQueryParam(key: string, defaultValue: string): string {
+    const value = req.query[key];
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value)) return value[0] ?? defaultValue;
+    return defaultValue;
+  }
 
+  const days = getQueryParam('days', '5');
+  const minVolume = getQueryParam('minVolume', '1000');
+  const minLargeTrades = getQueryParam('minLargeTrades', '5');
+  const largeTradePremium = getQueryParam('largeTradePremium', '50000');
+  const volumeMultiplier = getQueryParam('volumeMultiplier', '3');
+  const minIvPercent = getQueryParam('minIvPercent', '90');
+  const bearishRatio = getQueryParam('bearishRatio', '2');
+  const bullishRatio = getQueryParam('bullishRatio', '0.5');
   const start = new Date();
   const end = new Date(start.getTime() + parseInt(days) * 24 * 60 * 60 * 1000);
 

--- a/server/routes/earningsScreener.ts
+++ b/server/routes/earningsScreener.ts
@@ -1,0 +1,188 @@
+import { Router } from 'express';
+
+/**
+ * Earnings-based options screener.
+ *
+ * Implements multi-step process:
+ * 1. Fetch upcoming earnings within a window.
+ * 2. For each ticker, fetch options flow summary and filter by minimum volume and other criteria.
+ * 3. For tickers passing step 2, check short-dated ATM implied volatility.
+ *
+ * All external requests use the Unusual Whales API and require
+ * `process.env.UNUSUAL_WHALES_API_KEY` to be defined.
+ */
+
+interface EarningsEvent {
+  ticker?: string;
+  symbol?: string;
+  report_date?: string;
+  earnings_date?: string;
+}
+
+interface OptionsTrade {
+  premium?: number;
+}
+
+interface OptionsSummary {
+  total_volume?: number;
+  avg_30day_volume?: number;
+  put_call_premium_ratio?: number;
+  trades?: OptionsTrade[];
+}
+
+interface ChainOption {
+  expiration: string;
+  strike: number;
+  implied_volatility?: number;
+}
+
+interface ChainResponse {
+  expirations?: string[];
+  options?: ChainOption[];
+  underlying_price?: number;
+}
+
+interface Candidate {
+  ticker: string;
+  earningsDate: string;
+  totalVolume: number;
+  avg30Volume: number;
+  putCallPremiumRatio: number;
+  largeTrades: number;
+  atmIV: number;
+}
+
+const router = Router();
+
+// Helper to format date as YYYY-MM-DD
+function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+router.get('/earnings-screener', async (req, res) => {
+  const {
+    days = '5',
+    minVolume = '1000',
+    minLargeTrades = '5',
+    largeTradePremium = '50000',
+    volumeMultiplier = '3',
+    minIvPercent = '90',
+    bearishRatio = '2',
+    bullishRatio = '0.5',
+  } = req.query as Record<string, string>;
+
+  const start = new Date();
+  const end = new Date(start.getTime() + parseInt(days) * 24 * 60 * 60 * 1000);
+
+  try {
+    // Step 1: fetch upcoming earnings
+    const earningsResp = await fetch(
+      `https://api.unusualwhales.com/api/reference/earnings_calendar?start=${formatDate(start)}&end=${formatDate(end)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.UNUSUAL_WHALES_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    const earningsData = (await earningsResp.json()) as {
+      data?: EarningsEvent[];
+    };
+    const events = earningsData.data ?? [];
+
+    const candidates: Candidate[] = [];
+
+    for (const event of events) {
+      const ticker = event.ticker || event.symbol;
+      if (!ticker) continue;
+
+      // Step 2: options summary for ticker
+      const summaryResp = await fetch(
+        `https://api.unusualwhales.com/api/options/summary_for_ticker/${ticker}`,
+        {
+          headers: {
+            Authorization: `Bearer ${process.env.UNUSUAL_WHALES_API_KEY}`,
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+
+      if (!summaryResp.ok) continue;
+      const summary = (await summaryResp.json()) as OptionsSummary;
+
+      const totalVolume = summary.total_volume ?? 0;
+      const avg30 = summary.avg_30day_volume ?? 0;
+      const putCallRatio = summary.put_call_premium_ratio ?? 0;
+      const trades = summary.trades ?? [];
+
+      const largeTrades = trades.filter(
+        (t: OptionsTrade) => (t.premium ?? 0) >= parseFloat(largeTradePremium),
+      );
+
+      const volumeOk =
+        totalVolume > parseInt(minVolume) &&
+        totalVolume > parseFloat(volumeMultiplier) * avg30;
+      const ratioOk =
+        putCallRatio < parseFloat(bullishRatio) ||
+        putCallRatio > parseFloat(bearishRatio);
+      const largeTradesOk = largeTrades.length >= parseInt(minLargeTrades);
+
+      if (!volumeOk || !ratioOk || !largeTradesOk) continue;
+
+      // Step 3: check implied volatility
+      const chainResp = await fetch(
+        `https://api.unusualwhales.com/api/options/chain/${ticker}`,
+        {
+          headers: {
+            Authorization: `Bearer ${process.env.UNUSUAL_WHALES_API_KEY}`,
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      if (!chainResp.ok) continue;
+      const chain = (await chainResp.json()) as ChainResponse;
+
+      const earningsDate = new Date(event.report_date || event.earnings_date);
+      const expirations = chain.expirations ?? [];
+      const targetExp = expirations
+        .map((e) => new Date(e))
+        .filter((d) => d >= earningsDate)
+        .sort((a, b) => a.getTime() - b.getTime())[0];
+      if (!targetExp) continue;
+
+      const options = chain.options ?? [];
+      const underlying = chain.underlying_price ?? 0;
+      let atmIV = 0;
+      let bestDiff = Infinity;
+      for (const opt of options) {
+        if (opt.expiration !== formatDate(targetExp)) continue;
+        const diff = Math.abs(opt.strike - underlying);
+        if (diff < bestDiff) {
+          bestDiff = diff;
+          atmIV = opt.implied_volatility ?? 0;
+        }
+      }
+
+      if (atmIV * 100 < parseFloat(minIvPercent)) continue;
+
+      candidates.push({
+        ticker,
+        earningsDate: formatDate(earningsDate),
+        totalVolume,
+        avg30Volume: avg30,
+        putCallPremiumRatio: putCallRatio,
+        largeTrades: largeTrades.length,
+        atmIV: atmIV * 100,
+      });
+    }
+
+    res.json({ success: true, total: candidates.length, candidates });
+  } catch (err) {
+    console.error('earnings screener error', err);
+    res.status(500).json({ success: false, error: 'Failed to run earnings screener' });
+  }
+});
+
+export default router;
+

--- a/server/routes/earningsScreener.ts
+++ b/server/routes/earningsScreener.ts
@@ -80,7 +80,7 @@ router.get('/earnings-screener', async (req, res) => {
       `https://api.unusualwhales.com/api/reference/earnings_calendar?start=${formatDate(start)}&end=${formatDate(end)}`,
       {
         headers: {
-          Authorization: `Bearer ${process.env.UNUSUAL_WHALES_API_KEY}`,
+          Authorization: `Bearer ${apiKey}`,
           'Content-Type': 'application/json',
         },
       },

--- a/setup-dev-no-docker.sh
+++ b/setup-dev-no-docker.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+echo "🚀 Setting up UWIBKR development environment (No Docker)..."
+
+# Check if PostgreSQL is installed
+if ! command -v psql &> /dev/null; then
+    echo "📦 PostgreSQL not found. Installing..."
+    chmod +x install-postgresql.sh
+    ./install-postgresql.sh
+else
+    echo "✅ PostgreSQL already installed"
+    
+    # Start PostgreSQL service if not running
+    if ! sudo service postgresql status | grep -q "online"; then
+        echo "🔄 Starting PostgreSQL service..."
+        sudo service postgresql start
+    fi
+fi
+
+# Check if .env file exists
+if [ ! -f .env ]; then
+    echo "📝 Creating .env file from template..."
+    cp .env.example .env
+    echo "⚠️  Please edit .env file and add your UNUSUAL_WHALES_API_KEY"
+    echo "   You can get this from: https://unusualwhales.com/"
+fi
+
+# Install Node.js dependencies if needed
+if [ ! -d "node_modules" ]; then
+    echo "📦 Installing Node.js dependencies..."
+    npm install
+fi
+
+echo "📊 Running database migrations..."
+npm run db:push
+
+echo "✅ Setup complete!"
+echo ""
+echo "📋 Next steps:"
+echo "   1. Edit .env file and add your UNUSUAL_WHALES_API_KEY:"
+echo "      nano .env"
+echo "   2. Start the development server:"
+echo "      npm run dev"
+echo "   3. Test the earnings screener:"
+echo "      curl \"http://localhost:3000/api/earnings-screener\""
+echo ""
+echo "🔧 PostgreSQL Management Commands:"
+echo "   Start:  sudo service postgresql start"
+echo "   Stop:   sudo service postgresql stop"
+echo "   Status: sudo service postgresql status"

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+echo "🚀 Setting up UWIBKR local development environment..."
+
+# Check if Docker is installed
+if ! command -v docker &> /dev/null; then
+    echo "❌ Docker is not installed. Please install Docker first."
+    exit 1
+fi
+
+# Check if Docker Compose is available
+if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+    echo "❌ Docker Compose is not installed. Please install Docker Compose first."
+    exit 1
+fi
+
+# Check if .env file exists
+if [ ! -f .env ]; then
+    echo "📝 Creating .env file from template..."
+    cp .env.example .env
+    echo "⚠️  Please edit .env file and add your UNUSUAL_WHALES_API_KEY"
+    echo "   You can get this from: https://unusualwhales.com/"
+fi
+
+echo "🐘 Starting PostgreSQL database..."
+docker-compose up -d postgres
+
+echo "⏳ Waiting for database to be ready..."
+until docker-compose exec postgres pg_isready -U postgres; do
+    sleep 1
+done
+
+echo "📊 Running database migrations..."
+npm run db:push
+
+echo "✅ Database setup complete!"
+echo ""
+echo "📋 Next steps:"
+echo "   1. Edit .env file and add your UNUSUAL_WHALES_API_KEY"
+echo "   2. Run: npm run dev"
+echo "   3. Test the earnings screener at: http://localhost:3000/api/earnings-screener"
+echo ""
+echo "🔗 Database connection details:"
+echo "   Host: localhost"
+echo "   Port: 5432"
+echo "   Database: uwibkr_dev"
+echo "   Username: postgres"
+echo "   Password: postgres"

--- a/test-earnings-screener.js
+++ b/test-earnings-screener.js
@@ -1,0 +1,24 @@
+import express from 'express';
+import earningsScreenerRoutes from './server/routes/earningsScreener.js';
+
+const app = express();
+app.use(express.json());
+
+// Mount just the earnings screener route for testing
+app.use('/api', earningsScreenerRoutes);
+
+const PORT = process.env.PORT || 3001;
+
+app.listen(PORT, () => {
+  console.log(`🚀 Earnings Screener Test Server running on http://localhost:${PORT}`);
+  console.log(`📊 Test the earnings screener at: http://localhost:${PORT}/api/earnings-screener`);
+  console.log(`📋 Available query parameters:`);
+  console.log(`   - days: number of days ahead to search for earnings (default: 5)`);
+  console.log(`   - minVolume: minimum options volume (default: 1000)`);
+  console.log(`   - minLargeTrades: minimum number of large trades (default: 5)`);
+  console.log(`   - largeTradePremium: minimum premium for large trades (default: 50000)`);
+  console.log(`   - volumeMultiplier: volume vs 30-day average multiplier (default: 3)`);
+  console.log(`   - minIvPercent: minimum implied volatility percentage (default: 90)`);
+  console.log(`   - bearishRatio: put/call ratio threshold for bearish (default: 2)`);
+  console.log(`   - bullishRatio: put/call ratio threshold for bullish (default: 0.5)`);
+});

--- a/test-earnings-screener.sh
+++ b/test-earnings-screener.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "🧪 Testing UWIBKR Earnings Screener..."
+
+# Check if server is running
+if ! curl -s http://localhost:3000/api/health &> /dev/null; then
+    echo "❌ Server is not running. Start it with: npm run dev"
+    exit 1
+fi
+
+echo "📊 Testing earnings screener endpoint..."
+
+# Test with default parameters
+echo "Testing with default parameters..."
+curl -s "http://localhost:3000/api/earnings-screener" | jq '.'
+
+echo ""
+echo "Testing with custom parameters..."
+curl -s "http://localhost:3000/api/earnings-screener?days=3&minVolume=500&minIvPercent=75" | jq '.'
+
+echo ""
+echo "✅ Test complete!"

--- a/test-earnings-screener.sh
+++ b/test-earnings-screener.sh
@@ -2,21 +2,43 @@
 
 echo "🧪 Testing UWIBKR Earnings Screener..."
 
+# Check if PostgreSQL is running
+if ! sudo service postgresql status | grep -q "online"; then
+    echo "🔄 Starting PostgreSQL..."
+    sudo service postgresql start
+    sleep 2
+fi
+
 # Check if server is running
-if ! curl -s http://localhost:3000/api/health &> /dev/null; then
+if ! curl -s http://localhost:3000/api/system/health &> /dev/null; then
     echo "❌ Server is not running. Start it with: npm run dev"
+    echo "💡 In another terminal, run: npm run dev"
     exit 1
 fi
 
 echo "📊 Testing earnings screener endpoint..."
 
 # Test with default parameters
-echo "Testing with default parameters..."
-curl -s "http://localhost:3000/api/earnings-screener" | jq '.'
+echo "🔍 Testing with default parameters..."
+response=$(curl -s "http://localhost:3000/api/earnings-screener")
+if command -v jq &> /dev/null; then
+    echo "$response" | jq '.'
+else
+    echo "$response"
+fi
 
 echo ""
-echo "Testing with custom parameters..."
-curl -s "http://localhost:3000/api/earnings-screener?days=3&minVolume=500&minIvPercent=75" | jq '.'
+echo "🔍 Testing with custom parameters..."
+response=$(curl -s "http://localhost:3000/api/earnings-screener?days=3&minVolume=500&minIvPercent=75")
+if command -v jq &> /dev/null; then
+    echo "$response" | jq '.'
+else
+    echo "$response"
+fi
 
 echo ""
 echo "✅ Test complete!"
+echo ""
+echo "💡 Tips:"
+echo "   - Install jq for better JSON formatting: sudo apt install jq"
+echo "   - View logs in the terminal running 'npm run dev'"

--- a/test-env.mjs
+++ b/test-env.mjs
@@ -1,0 +1,17 @@
+import 'dotenv/config';
+
+console.log('🔍 Environment Variable Test');
+console.log('============================');
+console.log('DATABASE_URL:', process.env.DATABASE_URL || '❌ NOT SET');
+console.log('UNUSUAL_WHALES_API_KEY:', process.env.UNUSUAL_WHALES_API_KEY ? '✅ SET' : '❌ NOT SET');
+console.log('NODE_ENV:', process.env.NODE_ENV || 'undefined');
+console.log('PORT:', process.env.PORT || 'undefined');
+console.log('');
+
+if (process.env.DATABASE_URL) {
+    console.log('✅ Ready to start the application!');
+} else {
+    console.log('❌ DATABASE_URL is missing. Check your .env file.');
+    console.log('Expected format:');
+    console.log('DATABASE_URL=postgresql://postgres:postgres@localhost:5432/uwibkr_dev');
+}


### PR DESCRIPTION
## Summary
- add earnings-based options screener that chains earnings calendar, options flow and IV filters
- wire up earnings screener route into main server router
- annotate screener with explicit TypeScript interfaces to avoid implicit any types

## Testing
- `npx tsc server/routes/earningsScreener.ts --noEmit`
- `npm run check` *(fails: numerous existing TypeScript errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_688e48b3ae2883209e2420a85208db06