### PR TITLE
Add placeholder feeds and visualization pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,6 +33,11 @@ import OptionsScreenerPage from "@/pages/options-screener";
 import OptionsHeatMapPage from "@/pages/options-heatmap";
 import OptionsRadarPage from "@/pages/options-radar";
 import ShortExpiryDashboardPage from "@/pages/short-expiry-dashboard";
+import GammaSurfacePage from "@/pages/gamma-surface";
+import TimelineSweepsPage from "@/pages/timeline-sweeps";
+import FlowNetworkPage from "@/pages/flow-network";
+import WhaleScoreHeatMapPage from "@/pages/whale-score-heatmap";
+import SentimentFlowOverlayPage from "@/pages/sentiment-flow-overlay";
 import NotFound from "@/pages/not-found";
 
 function Router() {
@@ -66,6 +71,11 @@ function Router() {
       <Route path="/options-heatmap" component={OptionsHeatMapPage} />
       <Route path="/options-radar" component={OptionsRadarPage} />
       <Route path="/short-expiry" component={ShortExpiryDashboardPage} />
+      <Route path="/gamma-surface" component={GammaSurfacePage} />
+      <Route path="/sweeps-timeline" component={TimelineSweepsPage} />
+      <Route path="/flow-network" component={FlowNetworkPage} />
+      <Route path="/whale-score-heatmap" component={WhaleScoreHeatMapPage} />
+      <Route path="/sentiment-flow-overlay" component={SentimentFlowOverlayPage} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -28,6 +28,11 @@ const navigationItems = [
   { href: "/visual-transformer", label: "Visual Transformer", icon: "fas fa-eye" },
   { href: "/sentiment-heatmap", label: "Sentiment Heatmap", icon: "fas fa-fire" },
   { href: "/fundamentals", label: "Fundamentals Analysis", icon: "fas fa-building" },
+  { href: "/gamma-surface", label: "Gamma Surface", icon: "fas fa-mountain" },
+  { href: "/sweeps-timeline", label: "Timeline Sweeps", icon: "fas fa-stream" },
+  { href: "/flow-network", label: "Flow Network", icon: "fas fa-project-diagram" },
+  { href: "/whale-score-heatmap", label: "Whale Score Heatmap", icon: "fas fa-th" },
+  { href: "/sentiment-flow-overlay", label: "Sentiment vs Flow", icon: "fas fa-layer-group" },
   { href: "/settings", label: "Settings", icon: "fas fa-cog" },
 ];
 

--- a/client/src/pages/flow-network.tsx
+++ b/client/src/pages/flow-network.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function FlowNetworkPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Flow Network</h1>
+      <p>Network graph of cross-asset flow relationships coming soon.</p>
+    </div>
+  );
+}
+

--- a/client/src/pages/gamma-surface.tsx
+++ b/client/src/pages/gamma-surface.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function GammaSurfacePage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">3D Gamma Surface</h1>
+      <p>3D gamma surface visualization coming soon.</p>
+    </div>
+  );
+}
+

--- a/client/src/pages/sentiment-flow-overlay.tsx
+++ b/client/src/pages/sentiment-flow-overlay.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function SentimentFlowOverlayPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Sentiment vs Flow Overlay</h1>
+      <p>Combined sentiment and options flow view coming soon.</p>
+    </div>
+  );
+}
+

--- a/client/src/pages/timeline-sweeps.tsx
+++ b/client/src/pages/timeline-sweeps.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function TimelineSweepsPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Timeline Sweeps</h1>
+      <p>Animated timeline of large sweeps will appear here.</p>
+    </div>
+  );
+}
+

--- a/client/src/pages/whale-score-heatmap.tsx
+++ b/client/src/pages/whale-score-heatmap.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function WhaleScoreHeatMapPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Whale Score Heatmap</h1>
+      <p>Heatmap overlay of whale scoring will render here.</p>
+    </div>
+  );
+}
+

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -462,6 +462,57 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Additional Unusual Whales data feed routes
+  app.get("/api/unusual-whales/whale-roster", async (_req, res) => {
+    try {
+      const data = await uwService.getWhaleRoster();
+      res.json(data);
+    } catch (error) {
+      console.error("Failed to fetch whale roster:", error);
+      res.status(500).json({ message: "Failed to fetch whale roster" });
+    }
+  });
+
+  app.get("/api/unusual-whales/open-interest-delta", async (req, res) => {
+    try {
+      const data = await uwService.getOpenInterestDelta(req.query.ticker as string | undefined);
+      res.json(data);
+    } catch (error) {
+      console.error("Failed to fetch open interest delta:", error);
+      res.status(500).json({ message: "Failed to fetch open interest delta" });
+    }
+  });
+
+  app.get("/api/unusual-whales/dark-pool-scans", async (_req, res) => {
+    try {
+      const data = await uwService.getDarkPoolScans();
+      res.json(data);
+    } catch (error) {
+      console.error("Failed to fetch dark pool scans:", error);
+      res.status(500).json({ message: "Failed to fetch dark pool scans" });
+    }
+  });
+
+  app.get("/api/unusual-whales/multileg", async (req, res) => {
+    try {
+      const data = await uwService.detectMultiLegStrategies(req.query.ticker as string | undefined);
+      res.json(data);
+    } catch (error) {
+      console.error("Failed to detect multileg strategies:", error);
+      res.status(500).json({ message: "Failed to detect multileg strategies" });
+    }
+  });
+
+  app.get("/api/unusual-whales/sector-rotation", async (_req, res) => {
+    try {
+      const data = await uwService.getSectorRotation();
+      res.json(data);
+    } catch (error) {
+      console.error("Failed to fetch sector rotation data:", error);
+      res.status(500).json({ message: "Failed to fetch sector rotation data" });
+    }
+  });
+
   // LEAP Analysis endpoints
   app.get("/api/leaps/analyze", async (req, res) => {
     try {

--- a/server/services/unusualWhales.ts
+++ b/server/services/unusualWhales.ts
@@ -265,6 +265,60 @@ export class UnusualWhalesService {
     }
   }
 
+  // Additional data feed endpoints
+
+  async getWhaleRoster(): Promise<any[]> {
+    try {
+      const data = await this.makeRequest<{ data: any[] }>('/whales/roster');
+      return data.data || [];
+    } catch (error) {
+      console.error('Failed to fetch whale roster:', error);
+      return [];
+    }
+  }
+
+  async getOpenInterestDelta(ticker?: string): Promise<any[]> {
+    try {
+      const endpoint = ticker ? `/open-interest/delta/${ticker}` : '/open-interest/delta';
+      const data = await this.makeRequest<{ data: any[] }>(endpoint);
+      return data.data || [];
+    } catch (error) {
+      console.error('Failed to fetch open interest delta:', error);
+      return [];
+    }
+  }
+
+  async getDarkPoolScans(): Promise<any[]> {
+    try {
+      const data = await this.makeRequest<{ data: any[] }>('/dark-pool/alpha-scans');
+      return data.data || [];
+    } catch (error) {
+      console.error('Failed to fetch dark pool scans:', error);
+      return [];
+    }
+  }
+
+  async detectMultiLegStrategies(ticker?: string): Promise<any[]> {
+    try {
+      const endpoint = ticker ? `/option-trades/multileg/${ticker}` : '/option-trades/multileg';
+      const data = await this.makeRequest<{ data: any[] }>(endpoint);
+      return data.data || [];
+    } catch (error) {
+      console.error('Failed to detect multileg strategies:', error);
+      return [];
+    }
+  }
+
+  async getSectorRotation(): Promise<any[]> {
+    try {
+      const data = await this.makeRequest<{ data: any[] }>('/sector-rotation');
+      return data.data || [];
+    } catch (error) {
+      console.error('Failed to fetch sector rotation data:', error);
+      return [];
+    }
+  }
+
   getRequestStats() {
     return {
       requestCount: this.requestCount,


### PR DESCRIPTION
## Summary
- stub Unusual Whales data-feed methods for whale roster, open-interest delta, dark-pool scans, multileg detection and sector rotation
- expose new data-feed routes and add placeholder visualization pages and navigation links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: client/src/pages/leap-analysis.tsx(52,3): Property or signature expected.)*

------
https://chatgpt.com/codex/tasks/task_e_688e97cae9148320bedda0b0c3d95e5a