### PR TITLE
feat: add basic visualizations for advanced pages

### DIFF
--- a/client/src/pages/flow-network.tsx
+++ b/client/src/pages/flow-network.tsx
@@ -1,10 +1,43 @@
 import React from "react";
+import { ResponsiveContainer, Sankey, Tooltip } from "recharts";
+
+const data = {
+  nodes: [
+    { name: "Equities" },
+    { name: "ETF" },
+    { name: "Options" },
+    { name: "Futures" },
+  ],
+  links: [
+    { source: 0, target: 2, value: 300 },
+    { source: 1, target: 2, value: 160 },
+    { source: 2, target: 3, value: 80 },
+  ],
+};
 
 export default function FlowNetworkPage() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Flow Network</h1>
-      <p>Network graph of cross-asset flow relationships coming soon.</p>
+    <div className="p-4 space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold">Flow Network</h1>
+        <p className="text-muted-foreground">
+          Sample cross-asset flow relationships visualized as a Sankey diagram
+        </p>
+      </div>
+      <ResponsiveContainer width="100%" height={400}>
+        <Sankey
+          data={data}
+          nodePadding={40}
+          link={{ stroke: "#8884d8" }}
+          node={{
+            cursor: "pointer",
+            nodeWidth: 15,
+            stroke: "#555",
+          }}
+        >
+          <Tooltip />
+        </Sankey>
+      </ResponsiveContainer>
     </div>
   );
 }

--- a/client/src/pages/gamma-surface.tsx
+++ b/client/src/pages/gamma-surface.tsx
@@ -1,10 +1,67 @@
 import React from "react";
+import {
+  ResponsiveContainer,
+  ScatterChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  ZAxis,
+  Tooltip,
+  Scatter,
+} from "recharts";
+
+interface GammaPoint {
+  strike: number;
+  expiry: number; // days to expiry
+  gamma: number;
+}
+
+const gammaData: GammaPoint[] = [
+  { strike: 90, expiry: 7, gamma: 40 },
+  { strike: 100, expiry: 7, gamma: 75 },
+  { strike: 110, expiry: 7, gamma: 60 },
+  { strike: 90, expiry: 30, gamma: 30 },
+  { strike: 100, expiry: 30, gamma: 55 },
+  { strike: 110, expiry: 30, gamma: 35 },
+  { strike: 90, expiry: 60, gamma: 20 },
+  { strike: 100, expiry: 60, gamma: 45 },
+  { strike: 110, expiry: 60, gamma: 25 },
+];
 
 export default function GammaSurfacePage() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">3D Gamma Surface</h1>
-      <p>3D gamma surface visualization coming soon.</p>
+    <div className="p-4 space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold">3D Gamma Surface</h1>
+        <p className="text-muted-foreground">
+          Bubble size represents gamma by strike and days to expiry
+        </p>
+      </div>
+      <ResponsiveContainer width="100%" height={400}>
+        <ScatterChart>
+          <CartesianGrid />
+          <XAxis
+            type="number"
+            dataKey="strike"
+            name="Strike"
+            unit=""
+          />
+          <YAxis
+            type="number"
+            dataKey="expiry"
+            name="Days to Expiry"
+            unit="d"
+          />
+          <ZAxis
+            type="number"
+            dataKey="gamma"
+            name="Gamma"
+            range={[60, 400]}
+          />
+          <Tooltip cursor={{ strokeDasharray: "3 3" }} />
+          <Scatter data={gammaData} fill="#8884d8" />
+        </ScatterChart>
+      </ResponsiveContainer>
     </div>
   );
 }

--- a/client/src/pages/sentiment-flow-overlay.tsx
+++ b/client/src/pages/sentiment-flow-overlay.tsx
@@ -1,10 +1,59 @@
 import React from "react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+
+interface OverlayPoint {
+  time: string;
+  sentiment: number; // -1 to 1
+  flow: number; // contracts
+}
+
+const overlayData: OverlayPoint[] = [
+  { time: "09:30", sentiment: 0.2, flow: 10000 },
+  { time: "10:00", sentiment: -0.1, flow: 15000 },
+  { time: "10:30", sentiment: 0.4, flow: 18000 },
+  { time: "11:00", sentiment: 0.1, flow: 12000 },
+  { time: "11:30", sentiment: -0.2, flow: 9000 },
+  { time: "12:00", sentiment: 0.3, flow: 16000 },
+];
 
 export default function SentimentFlowOverlayPage() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Sentiment vs Flow Overlay</h1>
-      <p>Combined sentiment and options flow view coming soon.</p>
+    <div className="p-4 space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold">Sentiment vs Flow Overlay</h1>
+        <p className="text-muted-foreground">
+          Comparing market sentiment to options flow volume
+        </p>
+      </div>
+      <ResponsiveContainer width="100%" height={400}>
+        <LineChart data={overlayData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="time" />
+          <YAxis yAxisId="left" domain={[-1, 1]} />
+          <YAxis yAxisId="right" orientation="right" />
+          <Tooltip />
+          <Line
+            yAxisId="left"
+            type="monotone"
+            dataKey="sentiment"
+            stroke="#8884d8"
+          />
+          <Line
+            yAxisId="right"
+            type="monotone"
+            dataKey="flow"
+            stroke="#82ca9d"
+          />
+        </LineChart>
+      </ResponsiveContainer>
     </div>
   );
 }

--- a/client/src/pages/timeline-sweeps.tsx
+++ b/client/src/pages/timeline-sweeps.tsx
@@ -1,10 +1,47 @@
 import React from "react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+
+interface SweepPoint {
+  time: string;
+  volume: number;
+}
+
+const sweepData: SweepPoint[] = [
+  { time: "09:30", volume: 50 },
+  { time: "09:45", volume: 120 },
+  { time: "10:00", volume: 80 },
+  { time: "10:15", volume: 150 },
+  { time: "10:30", volume: 90 },
+  { time: "10:45", volume: 200 },
+  { time: "11:00", volume: 130 },
+];
 
 export default function TimelineSweepsPage() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Timeline Sweeps</h1>
-      <p>Animated timeline of large sweeps will appear here.</p>
+    <div className="p-4 space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold">Timeline Sweeps</h1>
+        <p className="text-muted-foreground">
+          Intraday sweep volume updated over time
+        </p>
+      </div>
+      <ResponsiveContainer width="100%" height={400}>
+        <LineChart data={sweepData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="time" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="volume" stroke="#8884d8" />
+        </LineChart>
+      </ResponsiveContainer>
     </div>
   );
 }

--- a/client/src/pages/whale-score-heatmap.tsx
+++ b/client/src/pages/whale-score-heatmap.tsx
@@ -1,10 +1,47 @@
 import React from "react";
 
+interface WhaleScore {
+  symbol: string;
+  score: number; // 0-1
+}
+
+const scores: WhaleScore[] = [
+  { symbol: "AAPL", score: 0.95 },
+  { symbol: "TSLA", score: 0.7 },
+  { symbol: "NVDA", score: 0.85 },
+  { symbol: "MSFT", score: 0.6 },
+  { symbol: "AMZN", score: 0.4 },
+  { symbol: "META", score: 0.3 },
+  { symbol: "NFLX", score: 0.8 },
+  { symbol: "GOOG", score: 0.5 },
+];
+
+const getColor = (score: number) => {
+  const hue = score * 120; // red to green
+  return `hsl(${hue}, 70%, 50%)`;
+};
+
 export default function WhaleScoreHeatMapPage() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Whale Score Heatmap</h1>
-      <p>Heatmap overlay of whale scoring will render here.</p>
+    <div className="p-4 space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold">Whale Score Heatmap</h1>
+        <p className="text-muted-foreground">
+          Higher scores indicate stronger institutional interest
+        </p>
+      </div>
+      <div className="grid grid-cols-4 gap-4">
+        {scores.map((s) => (
+          <div
+            key={s.symbol}
+            className="p-4 rounded text-center text-white"
+            style={{ backgroundColor: getColor(s.score) }}
+          >
+            <div className="text-lg font-semibold">{s.symbol}</div>
+            <div className="text-sm">{(s.score * 100).toFixed(0)}</div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement gamma surface scatter chart
- add timeline sweeps line chart
- visualize cross-asset flow with Sankey diagram
- create whale score heatmap grid
- overlay sentiment and flow volume in dual-axis chart

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: /client/src/pages/leap-analysis.tsx:52:8: ERROR: Unexpected "{")


------
https://chatgpt.com/codex/tasks/task_e_688e9b5496f48320aafd6aa815249633