### PR TITLE
feat: add preset filters for flow analysis

### DIFF
--- a/trading/filter_presets.py
+++ b/trading/filter_presets.py
@@ -1,0 +1,74 @@
+"""Preset filter configurations for Unusual Whales options flow."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass(frozen=True)
+class FilterPreset:
+    """Represents a saved set of query parameters for flow alerts."""
+
+    description: str
+    params: Dict[str, Any]
+
+
+FILTER_PRESETS: Dict[str, FilterPreset] = {
+    "clean_ask_side_opening_flow": FilterPreset(
+        description="Ask-side opening transactions within 5-minute interval",
+        params={
+            "interval": "5m",
+            "equity_type": "stocks",  # Remove ETFs and indices
+            "option_type": "both",
+            "volume_oi_ratio_min": 1.05,
+            "ask_percent_min": 0.7,
+            "percent_multi_max": 0.3,
+            "premium_min": 100000,
+            "exclude_in_the_money": True,
+            "interval_volume_greater_than_oi": True,
+            "total_volume_greater_than_oi": True,
+        },
+    ),
+    "general_flow_feed": FilterPreset(
+        description="Smaller to mid-sized orders with opening bias",
+        params={
+            "side": "bid,ask",
+            "equity_type": "stocks,adrs",
+            "premium_min": 750,
+            "premium_max": 25000,
+            "size_min": 5,
+            "volume_oi_ratio_min": 2,
+            "out_of_money_percent_min": 0.05,
+            "volume_greater_than_oi": True,
+            "size_greater_than_oi": True,
+            "opening_trades": True,
+            "exclude_deep_itm": True,
+            "hide_expired": True,
+        },
+    ),
+    "otm_call_buyers_500k": FilterPreset(
+        description="Single name $500K+ OTM call buyers for swing ideas",
+        params={
+            "option_type": "calls",
+            "side": "ask",
+            "opening_trades": True,
+            "equity_type": "stocks,adrs",
+            "premium_min": 500000,
+            "dte_min": 6,
+            "dte_max": 183,
+        },
+    ),
+    "single_leg_high_volume": FilterPreset(
+        description="Single leg, OTM options with significant volume",
+        params={
+            "contract_type": "option",
+            "issue_type": "common_stock",
+            "volume_oi_ratio_min": 2,
+            "premium_min": 2000,
+            "spread_max": 0,
+            "volume_greater_than_oi": True,
+            "is_out_of_money": True,
+        },
+    ),
+}
+

--- a/trading/options_flow_analyzer.py
+++ b/trading/options_flow_analyzer.py
@@ -1,10 +1,11 @@
 """Simplified options flow analysis using Unusual Whales API."""
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import requests
 
+from .filter_presets import FILTER_PRESETS
 
 BASE_URL = "https://api.unusualwhales.com"  # Placeholder
 
@@ -17,6 +18,33 @@ def fetch_unusual_trades(ticker: str) -> List[dict]:
     """
     try:
         resp = requests.get(f"{BASE_URL}/stocks/{ticker}/unusual").json()
+        return resp.get("data", [])
+    except Exception:
+        return []
+
+
+def fetch_filtered_flow(preset: str, ticker: Optional[str] = None) -> List[dict]:
+    """Fetch flow alerts using a preset filter configuration.
+
+    Parameters
+    ----------
+    preset:
+        Key referencing a preset in ``FILTER_PRESETS``.
+    ticker:
+        Optional single ticker to filter on.
+    """
+    cfg = FILTER_PRESETS.get(preset)
+    if cfg is None:
+        raise ValueError(f"Unknown preset: {preset}")
+
+    params = cfg.params.copy()
+    if ticker:
+        params["ticker"] = ticker
+
+    try:
+        resp = requests.get(
+            f"{BASE_URL}/api/option-trades/flow-alerts", params=params
+        ).json()
         return resp.get("data", [])
     except Exception:
         return []


### PR DESCRIPTION
## Summary
- add filter preset definitions for Unusual Whales flow queries
- support fetching flow alerts with a named preset

## Testing
- `python -m py_compile trading/filter_presets.py trading/options_flow_analyzer.py`
- `npm test` (fails: Missing script: "test")
- `npm run check` (fails: TypeScript compile errors)

------
https://chatgpt.com/codex/tasks/task_e_688f387521b08320b7f321968f22b174