### PR TITLE
Replace synthetic data with API-driven sources

### DIFF
--- a/server/routes/shortExpiryRoutes.ts
+++ b/server/routes/shortExpiryRoutes.ts
@@ -218,52 +218,32 @@ class ShortExpiryAnalyzer {
   }
 
   private async getOptionData(ticker: string, strike: number, expiry: string, type: string) {
-    try {
-      // Get option chain data from Unusual Whales or TWS
-      const optionChain = await this.unusualWhales.getOptionsChain(ticker, expiry);
-      const contract = optionChain.find((opt: any) => 
-        opt.strike === strike && opt.type === type
-      );
+    // Get option chain data from Unusual Whales or TWS
+    const optionChain = await this.unusualWhales.getOptionsChain(ticker, expiry);
+    const contract = optionChain.find((opt: any) =>
+      opt.strike === strike && opt.type === type
+    );
 
-      return contract ? {
-        midpoint: (contract.bid + contract.ask) / 2,
-        bid: contract.bid,
-        ask: contract.ask,
-        openInterest: contract.open_interest,
-        delta: contract.delta,
-        gamma: contract.gamma,
-        theta: contract.theta,
-        vega: contract.vega,
-        iv: contract.implied_volatility
-      } : null;
-    } catch (error) {
-      // Return mock data for demo
-      return {
-        midpoint: 2.50,
-        bid: 2.45,
-        ask: 2.55,
-        openInterest: 1000,
-        delta: 0.45,
-        gamma: 0.02,
-        theta: -0.05,
-        vega: 0.08,
-        iv: 0.25
-      };
-    }
+    return contract ? {
+      midpoint: (contract.bid + contract.ask) / 2,
+      bid: contract.bid,
+      ask: contract.ask,
+      openInterest: contract.open_interest,
+      delta: contract.delta,
+      gamma: contract.gamma,
+      theta: contract.theta,
+      vega: contract.vega,
+      iv: contract.implied_volatility
+    } : null;
   }
 
   private async getStockData(ticker: string) {
-    try {
-      const data = await this.unusualWhales.getStockQuote(ticker);
-      return {
-        price: data.price,
-        volume: data.volume,
-        avgVolume: data.avgVolume
-      };
-    } catch (error) {
-      // Fallback data
-      return { price: 100, volume: 1000000, avgVolume: 800000 };
-    }
+    const data = await this.unusualWhales.getStockQuote(ticker);
+    return {
+      price: data.price,
+      volume: data.volume,
+      avgVolume: data.avgVolume
+    };
   }
 
   private analyzeGexSentiment(gexData: any[], strike: number, optionType: string): 'bullish' | 'bearish' | 'neutral' {

--- a/server/services/leapAnalyzer.ts
+++ b/server/services/leapAnalyzer.ts
@@ -302,59 +302,7 @@ export class LEAPAnalyzer {
     }
     
     if (!leap) {
-      // Return a mock analysis for demonstration purposes
-      console.log(`Generating mock analysis for LEAP ID: ${leapId}`);
-      return {
-        trade: {
-          id: leapId,
-          ticker: 'ORCL',
-          strike: 260,
-          expiry: '2026-12-17',
-          type: 'call',
-          originalPremium: 550000,
-          originalPrice: 15.50,
-          daysToExpiry: 745,
-          probabilityScore: 78
-        },
-        analysis: {
-          timeDecay: {
-            daysElapsed: 15,
-            daysRemaining: 730,
-            timeDecayRate: 2.1,
-            accelerationPoint: 655
-          },
-          probabilityAssessment: {
-            overallScore: 78,
-            factors: {
-              premiumSize: 'Good',
-              volumeProfile: 'Strong',
-              moneyness: 'Optimal',
-              sectorStrength: 'Strong',
-              timeHorizon: 'Excellent'
-            }
-          },
-          riskReward: {
-            maxLoss: 550000,
-            breakeven: 275.50,
-            profitPotential: 'High',
-            currentRisk: 15.50
-          },
-          similarHistoricalTrades: [],
-          technicalLevels: {
-            currentUnderlying: 186.45,
-            strike: 260,
-            support: 167.8,
-            resistance: 205.1,
-            targetPrice: 312.0
-          },
-          recommendedActions: [
-            'Monitor closely for earnings impact',
-            'Consider rolling if underlying breaks resistance',
-            'EXCEPTIONAL conviction level',
-            'Strong institutional activity detected'
-          ]
-        }
-      };
+      throw new Error(`LEAP ${leapId} not found`);
     }
     
     // Update current prices if needed

--- a/server/services/signalEnhancer.ts
+++ b/server/services/signalEnhancer.ts
@@ -33,28 +33,27 @@ export class SignalEnhancer {
   private enhancedSignals: EnhancedSignal[] = [];
 
   constructor() {
-    this.initializeHistoricalData();
+    void this.initializeHistoricalData();
   }
 
-  private initializeHistoricalData(): void {
-    // Initialize with some mock historical data for common tickers
+  private async initializeHistoricalData(): Promise<void> {
     const commonTickers = ['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'TSLA', 'NVDA', 'META', 'NFLX'];
-    
-    commonTickers.forEach(ticker => {
-      // Generate realistic price history (random walk with drift)
-      const prices: number[] = [];
-      let currentPrice = 100 + Math.random() * 400; // Start between $100-$500
-      
-      for (let i = 0; i < 252; i++) { // 1 year of daily data
-        const drift = 0.0002; // slight upward drift
-        const volatility = 0.02; // 2% daily volatility
-        const randomChange = (Math.random() - 0.5) * 2 * volatility + drift;
-        currentPrice = currentPrice * (1 + randomChange);
-        prices.push(currentPrice);
+
+    for (const ticker of commonTickers) {
+      try {
+        const url = `https://query1.finance.yahoo.com/v8/finance/chart/${ticker}?range=1y&interval=1d`;
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error('Failed to fetch');
+        }
+        const json = await response.json();
+        const result = json.chart?.result?.[0];
+        const closes = result?.indicators?.quote?.[0]?.close || [];
+        this.historicalData.set(ticker, closes);
+      } catch (error) {
+        console.warn(`Failed to fetch historical data for ${ticker}:`, error);
       }
-      
-      this.historicalData.set(ticker, prices);
-    });
+    }
   }
 
   public async enhanceSignal(signal: any): Promise<EnhancedSignal> {

--- a/server/services/sophisticatedFiltering.ts
+++ b/server/services/sophisticatedFiltering.ts
@@ -162,29 +162,21 @@ export class SophisticatedFilteringService {
     timeWindow: number = 3600000 // 1 hour in ms
   ): Promise<DarkPoolActivity[]> {
     try {
-      // In real implementation, would fetch dark pool data
-      // For now, generate mock data based on typical patterns
-      
-      const now = Date.now();
-      const activities: DarkPoolActivity[] = [];
-
-      // Generate 3-5 mock dark pool activities in the time window
-      const activityCount = 3 + Math.floor(Math.random() * 3);
-      
-      for (let i = 0; i < activityCount; i++) {
-        const timestamp = new Date(now - Math.random() * timeWindow);
-        const volume = 10000 + Math.random() * 100000; // 10K-110K shares
-        const averagePrice = 150 + (Math.random() - 0.5) * 10; // ±$5 range
-        const direction = Math.random() > 0.5 ? 'buying' : 'selling';
-
-        activities.push({
-          volume,
-          averagePrice,
-          timestamp,
-          direction,
-        });
+      const apiUrl = process.env.DARK_POOL_API_URL;
+      if (!apiUrl) {
+        throw new Error('DARK_POOL_API_URL not configured');
       }
 
+      const response = await fetch(`${apiUrl}?symbol=${symbol}&window=${timeWindow}`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch dark pool data');
+      }
+
+      const json = await response.json();
+      const activities = (json || []).map((a: any) => ({
+        ...a,
+        timestamp: new Date(a.timestamp)
+      })) as DarkPoolActivity[];
       return activities.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
     } catch (error) {
       console.error('Failed to analyze dark pool correlation:', error);

--- a/server/services/transformerML.ts
+++ b/server/services/transformerML.ts
@@ -23,8 +23,8 @@ export interface TransformerPrediction {
   nextPrice: number;
   confidence: number;
   trend: 'bullish' | 'bearish' | 'neutral';
-  attention_weights: number[][];
-  feature_importance: { [key: string]: number };
+  attention_weights?: number[][][];
+  feature_importance?: { [key: string]: number };
 }
 
 export class TransformerMLEngine {
@@ -366,31 +366,13 @@ export class TransformerMLEngine {
       const maxTrendProb = Math.max(...Array.from(trendData));
       const confidence = maxTrendProb * (1 - Math.abs(priceData[0] - 0.5));
       
-      // Generate mock attention weights (in real implementation, extract from model)
-      const attentionWeights = Array(this.config.numHeads).fill(null).map(() =>
-        Array(this.config.sequenceLength).fill(null).map(() =>
-          Array(this.config.sequenceLength).fill(0).map(() => Math.random())
-        )
-      );
-      
-      // Feature importance analysis
-      const featureImportance = {
-        'price_momentum': Math.random() * 0.3 + 0.1,
-        'volume_profile': Math.random() * 0.25 + 0.05,
-        'technical_indicators': Math.random() * 0.2 + 0.1,
-        'temporal_patterns': Math.random() * 0.15 + 0.1,
-        'volatility_regime': Math.random() * 0.1 + 0.05
-      };
-      
       inputs.dispose();
       predictions.forEach(tensor => tensor.dispose());
-      
+
       return {
         nextPrice: priceData[0],
         confidence,
-        trend: trends[trendIndex],
-        attention_weights: attentionWeights,
-        feature_importance: featureImportance
+        trend: trends[trendIndex]
       };
       
     } catch (error) {
@@ -425,7 +407,7 @@ export class TransformerMLEngine {
     transformerScore = Math.max(0, Math.min(1, transformerScore));
     
     // Determine market regime
-    const volatility = prediction.feature_importance['volatility_regime'];
+    const volatility = prediction.feature_importance?.['volatility_regime'] ?? 0;
     let marketRegime = 'normal';
     if (volatility > 0.15) marketRegime = 'high_volatility';
     else if (volatility < 0.05) marketRegime = 'low_volatility';


### PR DESCRIPTION
## Summary
- Replace mock multi-timeframe analysis data with live market data fetched from Yahoo Finance.
- Remove synthetic fallbacks in option/stock helpers, LEAP analyzer, signal enhancer, and dark pool correlation.
- Require real image and market data for ensemble analysis and drop random attention weights in transformer engine.

## Testing
- `npm run check` *(fails: reportingEngine.ts parameter 't' implicitly has an 'any' type, and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f868fe4e88320827da099ebb48ecf