### PR TITLE
feat: add marketaux news source

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ GEMINI_API_KEY=your_gemini_key_here
 # Market Data
 UNUSUAL_WHALES_API_KEY=your_unusual_whales_key_here
 OPENFDA_API_KEY=your_fda_key_here
+MARKETAUX_API_KEY=your_marketaux_key_here
 
 # Trading (for live execution)
 IBKR_HOST=127.0.0.1


### PR DESCRIPTION
## Summary
- integrate MarketAux API into news service as secondary feed
- document MARKETAUX_API_KEY configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: implicit any, type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_688f8aee2abc8320842d1ff134577e18