### PR TITLE
feat: manual GEX refresh and watchlist filter

### DIFF
--- a/server/services/gexTracker.ts
+++ b/server/services/gexTracker.ts
@@ -112,7 +112,6 @@ export class GEXTracker {
       fs.mkdirSync(this.dataDir, { recursive: true });
     }
     this.loadWatchlists();
-    this.scheduleUpdates();
   }
 
   private getWatchlistMap(name: string = 'default'): Map<string, WatchlistItem> {
@@ -253,6 +252,17 @@ export class GEXTracker {
     }
     await this.saveWatchlists();
     console.log(`Removed ${symbols.length} symbols from watchlist ${listName}`);
+  }
+
+  async setSymbolEnabled(symbol: string, enabled: boolean, listName: string = 'default'): Promise<void> {
+    const list = this.getWatchlistMap(listName);
+    const item = list.get(symbol.toUpperCase());
+    if (item) {
+      item.enabled = enabled;
+      item.lastUpdated = new Date().toISOString();
+      await this.saveWatchlists();
+      console.log(`Set ${symbol} ${enabled ? 'enabled' : 'disabled'} in watchlist ${listName}`);
+    }
   }
 
   async clearWatchlist(listName: string = 'default'): Promise<void> {


### PR DESCRIPTION
## Summary
- fetch gamma exposure only when requested and add endpoint to trigger updates
- allow enabling/disabling tickers on the watchlist
- filter options flow and radar/screener alerts by active watchlist symbols

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_688fb6d881108320a5b0dfcadf6a7860