### PR TITLE
Use shared IBKR service for price data

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,7 +21,7 @@ import {
 import { WebSocketService } from "./services/websocket";
 import { SignalProcessor } from "./services/signalProcessor";
 import { RiskManager } from "./services/riskManager";
-import { IBKRService } from "./services/ibkr";
+import { ibkrService } from "./services/ibkr";
 import { getChannelSignals } from "./services/channelSignals";
 import { UnusualWhalesService } from "./services/unusualWhales";
 
@@ -193,13 +193,12 @@ function getIndustry(sector: string): string {
 
 export async function registerRoutes(app: Express): Promise<Server> {
   const httpServer = createServer(app);
-  
+
   // Initialize services
+  const uwService = new UnusualWhalesService();
   const wsService = new WebSocketService(httpServer, ibkrService, uwService);
   const signalProcessor = new SignalProcessor();
   const riskManager = new RiskManager();
-  const ibkrService = new IBKRService();
-  const uwService = new UnusualWhalesService();
 
   // Start services
   await ibkrService.connect();


### PR DESCRIPTION
## Summary
- Ensure server uses a single shared IBKR service instance
- Connect to IBKR once and pass to WebSocket service for price data

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688fbb9108a48320b5babc5af3b8185b