### PR TITLE
fix: load macro data with real APIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/uwibkr_dev"
 # API Keys
 UNUSUAL_WHALES_API_KEY="your_unusual_whales_api_key_here"
 FMP_API_KEY="your_fmp_api_key_here"
+FRED_API_KEY="your_fred_api_key_here"
+
+# IBKR connection details
+IBKR_HOST="localhost"
+IBKR_PORT="7497"
+IBKR_CLIENT_ID="1"
+IBKR_API_URL="https://localhost:5000/v1/api"
 
 # Optional: Other environment variables
 NODE_ENV="development"

--- a/server/services/macroeconomicData.ts
+++ b/server/services/macroeconomicData.ts
@@ -1,8 +1,4 @@
 // @ts-nocheck
-import OpenAI from 'openai';
-
-// Create OpenAI instance directly for macroeconomic analysis
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 export interface MacroeconomicIndicators {
   timestamp: Date;
@@ -191,7 +187,7 @@ export class MacroeconomicDataService {
   async fetchSentimentIndicators(): Promise<MacroeconomicIndicators['sentimentIndicators']> {
     try {
       // Get VIX and other market data from TWS
-      const { ibkrService } = await import('./ibkrService');
+      const { ibkrService } = await import('./ibkr');
       
       const [vixData, dxyData, goldData, oilData] = await Promise.allSettled([
         ibkrService.getMarketData('VIX'),
@@ -232,7 +228,7 @@ export class MacroeconomicDataService {
   // Calculate Fear & Greed Index components
   async calculateFearGreedComponents(): Promise<MacroeconomicIndicators['fearGreedComponents']> {
     try {
-      const { ibkrService } = await import('./ibkrService');
+      const { ibkrService } = await import('./ibkr');
       
       // 1. Market Momentum (S&P 500 vs 125-day MA)
       const spyData = await ibkrService.getHistoricalData('SPY', '6M');
@@ -577,7 +573,7 @@ export class MacroeconomicDataService {
   private async calculateSafeHavenDemand(): Promise<number> {
     try {
       // Compare Treasury ETF (TLT) vs SPY performance
-      const { ibkrService } = await import('./ibkrService');
+      const { ibkrService } = await import('./ibkr');
       const [tltData, spyData] = await Promise.all([
         ibkrService.getHistoricalData('TLT', '1M'),
         ibkrService.getHistoricalData('SPY', '1M')


### PR DESCRIPTION
## Summary
- remove unused OpenAI client so macro service doesn't require OpenAI API key
- correct IBKR import paths for sentiment and safe-haven calculations
- document FRED and IBKR config options in `.env.example`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688fc2ea10dc8320b7a5ea4d8e1bb448