### PR TITLE
Add data source fallbacks and watchlist fundamentals

### DIFF
--- a/server/services/marketIntelligence.ts
+++ b/server/services/marketIntelligence.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { gexTracker, type DarkPoolData, type InsiderTrade, type AnalystUpdate, type NewsAlert } from './gexTracker';
+import { fundamentalsAnalyzer } from './fundamentalsAnalyzer';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -24,6 +25,17 @@ export class MarketIntelligenceService {
       fs.mkdirSync(this.dataDir, { recursive: true });
     }
     this.loadAlertHistory();
+  }
+
+  async trackFundamentalData(symbol: string): Promise<any> {
+    try {
+      const data = await fundamentalsAnalyzer.getFundamentals(symbol);
+      await this.saveFundamentalsData(symbol, data);
+      return data;
+    } catch (error) {
+      console.error(`Error tracking fundamentals for ${symbol}:`, error);
+      return null;
+    }
   }
 
   async trackDarkPoolActivity(symbol: string): Promise<DarkPoolData | null> {
@@ -388,6 +400,11 @@ export class MarketIntelligenceService {
     existingAlerts = existingAlerts.filter(alert => new Date(alert.publishedAt) > sevenDaysAgo);
     
     fs.writeFileSync(filePath, JSON.stringify(existingAlerts, null, 2));
+  }
+
+  private async saveFundamentalsData(symbol: string, data: any): Promise<void> {
+    const filePath = path.join(this.dataDir, `${symbol}_fundamentals.json`);
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
   }
 
   private async saveAlertHistory(): Promise<void> {


### PR DESCRIPTION
## Summary
- add Financial Modeling Prep fallback to fundamentals analyzer and merge into combined results
- schedule daily watchlist updates to capture fundamentals, saving them through market intelligence service
- supplement macroeconomic service with Alpha Vantage fallback for treasury rates and core indicators

## Testing
- `npm run check`
- `node test-env.mjs`
- `OPENAI_API_KEY=dummy npx tsx -e "import('./server/services/marketIntelligence.ts').then(async m=>{await m.marketIntelligence.trackFundamentalData('AAPL');console.log('done');});"` *(fails: ERR_MODULE_NOT_FOUND: file:///workspace/UWIBKR/server/services/ibkrService)*

------
https://chatgpt.com/codex/tasks/task_e_688fc53d5aa88320817916eb284e213c