### PR TITLE
Add high probability options flow alert preset

### DIFF
--- a/trading/filter_presets.py
+++ b/trading/filter_presets.py
@@ -70,5 +70,20 @@ FILTER_PRESETS: Dict[str, FilterPreset] = {
             "is_out_of_money": True,
         },
     ),
+    "most_successful_combined_strategy": FilterPreset(
+        description="High-probability OTM call alert using top trader settings",
+        params={
+            "option_type": "calls",
+            "side": "ask",
+            "is_out_of_money": True,
+            "premium_min": 500000,
+            "volume_oi_ratio_min": 2,
+            "equity_type": "stocks,adrs",
+            "opening_trades": True,
+            "dte_min": 1,
+            "dte_max": 28,
+            "rule_name[]": "RepeatedHits",
+        },
+    ),
 }
 

--- a/trading/options_flow_analyzer.py
+++ b/trading/options_flow_analyzer.py
@@ -8,6 +8,7 @@ import requests
 from .filter_presets import FILTER_PRESETS
 
 BASE_URL = "https://api.unusualwhales.com"  # Placeholder
+HIGH_PROBABILITY_PRESET = "most_successful_combined_strategy"
 
 
 def fetch_unusual_trades(ticker: str) -> List[dict]:
@@ -48,6 +49,17 @@ def fetch_filtered_flow(preset: str, ticker: Optional[str] = None) -> List[dict]
         return resp.get("data", [])
     except Exception:
         return []
+
+
+def fetch_high_probability_alerts(ticker: Optional[str] = None) -> List[dict]:
+    """Fetch highest probability flow alerts using the combined strategy preset.
+
+    Parameters
+    ----------
+    ticker:
+        Optional single ticker to filter on.
+    """
+    return fetch_filtered_flow(HIGH_PROBABILITY_PRESET, ticker)
 
 
 def analyze_flow_sentiment(ticker: str) -> float:


### PR DESCRIPTION
## Summary
- add `most_successful_combined_strategy` preset combining premium, ask-side, volume/oi and repeat-hit criteria
- expose `fetch_high_probability_alerts` helper to retrieve flow alerts using this preset

## Testing
- `npm test` *(fails: Missing script "test")*
- `python -m py_compile trading/filter_presets.py trading/options_flow_analyzer.py`


------
https://chatgpt.com/codex/tasks/task_e_688ff05292fc8320921a5d2ddf97dbd2