### PR TITLE
feat: add modular trading agents

### DIFF
--- a/trading/agents/README.md
+++ b/trading/agents/README.md
@@ -1,0 +1,27 @@
+# Agent Components
+
+This package provides a modular multi-agent trading framework built with the
+[Google Agent Development Kit](https://ai.google.dev/). Each agent focuses on a
+single responsibility and can be developed, tested, and deployed independently.
+Integration is primarily about passing data in common Python structures like
+`pandas.DataFrame` and dictionaries.
+
+## Available Agents
+
+- **AlphaSignalAgent** – technical-analysis driven signal generation using SMA
+  crossovers.
+- **RiskManagementAgent** – circuit breaker enforcing position and sector
+  limits.
+- **StrategyOrchestrator** – deterministic coordinator ensuring the correct
+  sequence of data curation, signal evaluation, risk checks and execution.
+- **DataCurationAgent** – cleans and enriches raw market data with common
+  indicators so multiple alpha agents can share features.
+- **DynamicStrategyAgent** – LLM-powered meta strategy component that can adjust
+  other agents in real time based on unstructured context such as news or human
+  input.
+- **PostTradeAnalysisAgent** – collects execution metrics to close the feedback
+  loop for optimisation.
+
+The design emphasises modularity: specialised agents accelerate data processing
+and safeguard execution, while the dynamic strategy and post-trade components
+allow the system to adapt and learn from outcomes.

--- a/trading/agents/__init__.py
+++ b/trading/agents/__init__.py
@@ -1,0 +1,16 @@
+"""Agent implementations leveraging Google Agent Development Kit."""
+from .alpha_agent import AlphaSignalAgent
+from .risk_management_agent import RiskManagementAgent
+from .strategy_orchestrator import StrategyOrchestrator
+from .data_curation_agent import DataCurationAgent
+from .dynamic_strategy_agent import DynamicStrategyAgent
+from .post_trade_analysis_agent import PostTradeAnalysisAgent
+
+__all__ = [
+    "AlphaSignalAgent",
+    "RiskManagementAgent",
+    "StrategyOrchestrator",
+    "DataCurationAgent",
+    "DynamicStrategyAgent",
+    "PostTradeAnalysisAgent",
+]

--- a/trading/agents/alpha_agent.py
+++ b/trading/agents/alpha_agent.py
@@ -1,0 +1,35 @@
+"""Alpha/Signal agent using SMA crossover and Google Agent Development Kit placeholder."""
+from __future__ import annotations
+from dataclasses import dataclass
+import pandas as pd
+import pandas_ta as ta
+
+@dataclass
+class AlphaSignalAgent:
+    """Generate trading signals from market data.
+
+    Uses a simple moving average (SMA) crossover strategy. The agent can be
+    extended to integrate with Google Agent Development Kit components that
+    provide additional analytical capabilities.
+    """
+    short_window: int = 20
+    long_window: int = 50
+
+    def analyze_market_data(self, market_data: pd.DataFrame) -> str:
+        """Return BUY, SELL or HOLD based on SMA crossover."""
+        if len(market_data) < self.long_window:
+            return "HOLD"
+
+        market_data.ta.sma(length=self.short_window, append=True)
+        market_data.ta.sma(length=self.long_window, append=True)
+
+        last_short = market_data[f"SMA_{self.short_window}"].iloc[-1]
+        last_long = market_data[f"SMA_{self.long_window}"].iloc[-1]
+        prev_short = market_data[f"SMA_{self.short_window}"].iloc[-2]
+        prev_long = market_data[f"SMA_{self.long_window}"].iloc[-2]
+
+        if prev_short <= prev_long and last_short > last_long:
+            return "BUY"
+        if prev_short >= prev_long and last_short < last_long:
+            return "SELL"
+        return "HOLD"

--- a/trading/agents/data_curation_agent.py
+++ b/trading/agents/data_curation_agent.py
@@ -1,0 +1,17 @@
+"""High-speed data curation and feature engineering agent."""
+from __future__ import annotations
+from dataclasses import dataclass
+import pandas as pd
+import pandas_ta as ta
+
+@dataclass
+class DataCurationAgent:
+    """Prepare raw market data for alpha agents."""
+    def prepare(self, market_data: pd.DataFrame) -> pd.DataFrame:
+        """Clean and enrich market data with additional features."""
+        df = market_data.copy()
+        df.fillna(method="ffill", inplace=True)
+        df.ta.rsi(append=True)
+        df.ta.macd(append=True)
+        df.ta.bbands(append=True)
+        return df

--- a/trading/agents/dynamic_strategy_agent.py
+++ b/trading/agents/dynamic_strategy_agent.py
@@ -1,0 +1,35 @@
+"""LLM-powered dynamic strategy agent using Google Agent Development Kit."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+
+import google.genai as genai
+
+
+@dataclass
+class DynamicStrategyAgent:
+    """Adjust behaviour of other agents based on unstructured context."""
+    model: str = "gemini-1.5-flash"
+    api_key: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.client = genai.Client(api_key=self.api_key) if self.api_key else None
+
+    def adjust(self, alpha_agent, risk_agent, context: str | None = None) -> None:
+        """Use an LLM to modify agent parameters."""
+        if not self.client or context is None:
+            return
+        prompt = (
+            "Given the following context, suggest new short/long windows and risk "
+            f"limits: {context}"
+        )
+        response = self.client.models.generate_content(model=self.model, contents=prompt)
+        text = response.text or ""
+        # Basic parsing of numbers from response text; in a real system this
+        # would involve structured outputs or JSON.
+        import re
+        numbers = [int(n) for n in re.findall(r"\d+", text)]
+        if len(numbers) >= 2:
+            alpha_agent.short_window, alpha_agent.long_window = numbers[:2]
+        if len(numbers) >= 3:
+            risk_agent.max_position_size = float(numbers[2])

--- a/trading/agents/post_trade_analysis_agent.py
+++ b/trading/agents/post_trade_analysis_agent.py
@@ -1,0 +1,13 @@
+"""Agent for post-trade analysis and feedback."""
+from __future__ import annotations
+from dataclasses import dataclass
+
+
+@dataclass
+class PostTradeAnalysisAgent:
+    """Evaluate executed trades for continuous improvement."""
+    def evaluate(self, symbol: str, trade_details: dict, result: dict) -> None:
+        """Placeholder for post-trade analytics."""
+        # In a full implementation this would record slippage, execution time,
+        # and other metrics, potentially storing results for model retraining.
+        pass

--- a/trading/agents/risk_management_agent.py
+++ b/trading/agents/risk_management_agent.py
@@ -1,0 +1,23 @@
+"""Risk management agent acting as circuit breaker."""
+from __future__ import annotations
+from dataclasses import dataclass
+
+@dataclass
+class RiskManagementAgent:
+    """Validate trades against predefined risk rules."""
+    max_position_size: float = 10000.0
+    max_sector_exposure: float = 0.25
+
+    def assess_trade(self, proposed_trade: dict, current_portfolio: dict) -> bool:
+        """Return True if trade is within limits, otherwise False."""
+        trade_value = proposed_trade["value"]
+        trade_sector = proposed_trade["sector"]
+        if trade_value > self.max_position_size:
+            return False
+
+        portfolio_value = current_portfolio["total_value"]
+        current_sector_value = current_portfolio["sector_exposure"].get(trade_sector, 0.0) * portfolio_value
+        new_sector_value = current_sector_value + trade_value
+        new_total = portfolio_value + trade_value
+        new_exposure = new_sector_value / new_total
+        return new_exposure <= self.max_sector_exposure

--- a/trading/agents/strategy_orchestrator.py
+++ b/trading/agents/strategy_orchestrator.py
@@ -1,0 +1,48 @@
+"""Deterministic orchestrator coordinating specialized agents."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+
+from .alpha_agent import AlphaSignalAgent
+from .risk_management_agent import RiskManagementAgent
+
+# Optional agents for enhanced capabilities
+from .data_curation_agent import DataCurationAgent
+from .dynamic_strategy_agent import DynamicStrategyAgent
+from .post_trade_analysis_agent import PostTradeAnalysisAgent
+
+
+@dataclass
+class StrategyOrchestrator:
+    """Coordinate the workflow between trading agents.
+
+    The orchestrator enforces a strict sequence: curate data, obtain a signal,
+    check risk, execute, and perform post-trade analysis. The optional dynamic
+    strategy agent can modify behaviour in response to external context using
+    the Google Agent Development Kit.
+    """
+    alpha_agent: AlphaSignalAgent
+    risk_agent: RiskManagementAgent
+    execution_agent: object  # Placeholder type
+    data_agent: Optional[DataCurationAgent] = None
+    dynamic_agent: Optional[DynamicStrategyAgent] = None
+    analysis_agent: Optional[PostTradeAnalysisAgent] = None
+
+    def run_cycle(self, symbol: str, market_data, portfolio_state, trade_details) -> None:
+        """Execute one trading cycle."""
+        if self.data_agent:
+            market_data = self.data_agent.prepare(market_data)
+        if self.dynamic_agent:
+            self.dynamic_agent.adjust(self.alpha_agent, self.risk_agent)
+
+        signal = self.alpha_agent.analyze_market_data(market_data)
+        if signal == "HOLD":
+            return
+
+        if not self.risk_agent.assess_trade(trade_details, portfolio_state):
+            return
+
+        self.execution_agent.execute_trade(symbol=symbol, action=signal, quantity=trade_details["quantity"])
+
+        if self.analysis_agent:
+            self.analysis_agent.evaluate(symbol, trade_details, result={})


### PR DESCRIPTION
## Summary
- add alpha, risk, orchestrator, and supporting agents built around Google Agent Development Kit
- include LLM-powered dynamic strategy agent and post-trade analysis stubs
- document modular agent architecture and integration

## Testing
- `python -m py_compile trading/agents/*.py`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_688ff33dd09c832089056bc26a7ad1ef