### PR TITLE
feat: add sector greek flow to market sentiment

### DIFF
--- a/server/services/unusualWhales.ts
+++ b/server/services/unusualWhales.ts
@@ -320,6 +320,17 @@ export class UnusualWhalesService {
     }
   }
 
+  async getGroupGreekFlow(flowGroup: string, date?: string): Promise<any> {
+    try {
+      const encodedGroup = encodeURIComponent(flowGroup.toLowerCase());
+      const query = date ? `?date=${date}` : '';
+      return await this.makeRequest<any>(`/group-flow/${encodedGroup}/greek-flow${query}`);
+    } catch (error) {
+      console.error('Failed to fetch group greek flow data:', error);
+      return null;
+    }
+  }
+
   async getEtfTide(ticker: string, date?: string): Promise<any> {
     try {
       const query = date ? `?date=${date}` : '';


### PR DESCRIPTION
## Summary
- retrieve group-flow Greek flow from Unusual Whales
- integrate sector Greek flow into market sentiment options flow metrics

## Testing
- `npm test` (fails: missing script "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68900cb79004832089175f3af1de6bbc