### PR TITLE
feat: show ticker update times on watchlist

### DIFF
--- a/client/src/pages/watchlist.tsx
+++ b/client/src/pages/watchlist.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -78,7 +78,10 @@ export default function WatchlistPage() {
       try {
         const msg = JSON.parse(event.data);
         if (msg.type === 'quote_update' && msg.data?.symbol) {
-          setQuotes((prev) => ({ ...prev, [msg.data.symbol]: msg.data }));
+          setQuotes((prev) => ({
+            ...prev,
+            [msg.data.symbol]: { ...msg.data, timestamp: msg.timestamp }
+          }));
         }
       } catch {
         // ignore parse errors
@@ -94,6 +97,18 @@ export default function WatchlistPage() {
     queryKey: [`/api/gex/levels?list=${currentList}`],
     enabled: false,
   });
+
+  useEffect(() => {
+    refetchGex();
+  }, [currentList, refetchGex]);
+
+  const gexMap = useMemo(() => {
+    const map: Record<string, any> = {};
+    (gexLevels || []).forEach((g: any) => {
+      map[g.symbol] = g;
+    });
+    return map;
+  }, [gexLevels]);
 
   // Fetch intelligence for selected symbol
   const { data: intelligence } = useQuery({
@@ -388,6 +403,7 @@ export default function WatchlistPage() {
                 const price = typeof quote.last === 'number' ? quote.last : item.price;
                 const change = typeof quote.change === 'number' ? quote.change : item.change;
                 const changePercent = typeof quote.changePct === 'number' ? quote.changePct : item.changePercent;
+                const gex = gexMap[item.symbol];
                 return (
                   <Card key={item.symbol} className="cursor-pointer hover:shadow-md transition-shadow" onClick={() => setSelectedSymbol(item.symbol)}>
                     <CardHeader className="pb-2">
@@ -417,6 +433,19 @@ export default function WatchlistPage() {
                                 {typeof changePercent === 'number' && ` (${changePercent.toFixed(2)}%)`}
                               </span>
                             )}
+                          </div>
+                        )}
+                        {quote.timestamp && (
+                          <div className="text-xs text-gray-500">
+                            Price updated: {new Date(quote.timestamp).toLocaleString()}
+                          </div>
+                        )}
+                        {gex && (
+                          <div>
+                            Net Gamma: {gex.netGamma?.toFixed(2)}
+                            <div className="text-xs text-gray-500">
+                              GEX updated: {new Date(gex.date).toLocaleString()}
+                            </div>
                           </div>
                         )}
                         {expandedSymbols.includes(item.symbol) && (

--- a/server/services/gexTracker.ts
+++ b/server/services/gexTracker.ts
@@ -456,6 +456,7 @@ export class GEXTracker {
     console.log(`Updating GEX data for ${symbols.length} symbols in ${listName} watchlist...`);
     const { marketIntelligence } = await import('./marketIntelligence');
     const results = { success: 0, failed: 0, errors: [] as string[] };
+    const list = this.getWatchlistMap(listName);
 
     for (const symbol of symbols) {
       try {
@@ -467,6 +468,10 @@ export class GEXTracker {
           marketIntelligence.trackNewsAlerts(symbol),
           marketIntelligence.trackFundamentalData(symbol),
         ]);
+        const item = list.get(symbol);
+        if (item) {
+          item.lastUpdated = new Date().toISOString();
+        }
         results.success++;
         console.log(`✅ Updated data for ${symbol}`);
       } catch (error) {
@@ -475,6 +480,8 @@ export class GEXTracker {
         console.error(`Failed to update data for ${symbol}:`, error);
       }
     }
+
+    await this.saveWatchlists();
 
     if (results.errors.length > 0) {
       console.log('Update errors:', results.errors);
@@ -513,7 +520,7 @@ export class GEXTracker {
 
       const gexData: GEXData = {
         symbol,
-        date: new Date().toISOString().split('T')[0],
+        date: new Date().toISOString(),
         totalGamma,
         callGamma,
         putGamma,


### PR DESCRIPTION
## Summary
- track GEX updates with precise timestamps
- show full price and GEX update times on each watchlist card

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68901e9c508c8320bac6ae549e99b83e