### PR TITLE
Allow simple CSV watchlist import and improve GEX fallback

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2540,15 +2540,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       const symbols: any[] = [];
-      csv.parseString(csvContent, { headers: true })
+      csv.parseString(csvContent, { headers: false, trim: true })
         .on('data', (row: any) => {
-          if (row.Symbol && row.Symbol !== 'Symbol') {
-            const sector = getSectorForSymbol(row.Symbol);
+          const symbol = row.Symbol || row[0];
+          if (symbol && symbol !== 'Symbol') {
+            const sector = getSectorForSymbol(symbol);
             symbols.push({
-              symbol: row.Symbol,
+              symbol,
               sector,
               enabled: true,
-              gexTracking: !['VIX'].includes(row.Symbol)
+              gexTracking: !['VIX'].includes(symbol)
             });
           }
         })

--- a/server/services/gexTracker.ts
+++ b/server/services/gexTracker.ts
@@ -492,11 +492,17 @@ export class GEXTracker {
     try {
       const { UnusualWhalesService } = await import('./unusualWhales');
       const uw = new UnusualWhalesService();
-      const exposures = await uw.getSpotExposures(symbol);
+      let exposures = await uw.getSpotExposures(symbol);
+      let dataDate = new Date();
 
       if (!exposures.length) {
-        console.warn(`No GEX data available for ${symbol}`);
-        return;
+        const lastFriday = this.getLastFriday();
+        exposures = await uw.getSpotExposures(symbol, lastFriday);
+        if (!exposures.length) {
+          console.warn(`No GEX data available for ${symbol}`);
+          return;
+        }
+        dataDate = new Date(lastFriday);
       }
 
       const totalGamma = exposures.reduce(
@@ -520,7 +526,7 @@ export class GEXTracker {
 
       const gexData: GEXData = {
         symbol,
-        date: new Date().toISOString(),
+        date: dataDate.toISOString(),
         totalGamma,
         callGamma,
         putGamma,
@@ -551,14 +557,29 @@ export class GEXTracker {
     }
   }
 
+  private getLastFriday(): string {
+    const date = new Date();
+    const day = date.getDay();
+    const diff = day >= 5 ? day - 5 : day + 2;
+    date.setDate(date.getDate() - diff);
+    return date.toISOString().split('T')[0];
+  }
+
   async getGEXLevels(symbol: string): Promise<GEXLevels | null> {
     try {
       const filePath = path.join(this.dataDir, `${symbol}_gex.json`);
       if (!fs.existsSync(filePath)) {
+        await this.updateSymbolGEX(symbol);
+      }
+      if (!fs.existsSync(filePath)) {
         return null;
       }
 
-      const data: GEXData[] = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      let data: GEXData[] = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      if (!data.length) {
+        await this.updateSymbolGEX(symbol);
+        data = fs.existsSync(filePath) ? JSON.parse(fs.readFileSync(filePath, 'utf8')) : [];
+      }
       const latest = data[data.length - 1];
 
       if (!latest) return null;

--- a/server/services/unusualWhales.ts
+++ b/server/services/unusualWhales.ts
@@ -174,9 +174,12 @@ export class UnusualWhalesService {
     }
   }
 
-  async getSpotExposures(ticker: string): Promise<GammaExposure[]> {
+  async getSpotExposures(ticker: string, date?: string): Promise<GammaExposure[]> {
     try {
-      const data = await this.makeRequest<{ data: GammaExposure[] }>(`/stock/${ticker}/spot-exposures/strike`);
+      const endpoint = date
+        ? `/stock/${ticker}/spot-exposures/strike?date=${date}`
+        : `/stock/${ticker}/spot-exposures/strike`;
+      const data = await this.makeRequest<{ data: GammaExposure[] }>(endpoint);
       return data.data || [];
     } catch (error) {
       console.error(`Failed to fetch spot exposures for ${ticker}:`, error);


### PR DESCRIPTION
## Summary
- allow watchlist CSV uploads with just a column of tickers
- fetch previous Friday's data when no GEX info is available
- support optional date parameter in Unusual Whales spot exposure requests

## Testing
- `npm run check`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689028c6c8ec83209e37599794494fcf