### PR TITLE
Add sector sentiment gauge using tide and expiry flow

### DIFF
--- a/client/src/components/SectorSentimentPanel.tsx
+++ b/client/src/components/SectorSentimentPanel.tsx
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+import { Progress } from "@/components/ui/progress";
+import { ArrowDown, ArrowUp } from "lucide-react";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { BarChart, Bar, XAxis } from "recharts";
+
+interface SectorSentimentProps {
+  sector?: string;
+}
+
+export default function SectorSentimentPanel({ sector = "technology" }: SectorSentimentProps) {
+  const { data, isLoading } = useQuery<any>({
+    queryKey: ["/api/sentiment/sector", sector, "tide-expiry"],
+    queryFn: async () => {
+      const res = await fetch(`/api/sentiment/sector/${sector}/tide-expiry`);
+      if (!res.ok) throw new Error("Failed to fetch sector sentiment");
+      return res.json();
+    },
+    refetchInterval: 60000,
+  });
+
+  if (isLoading || !data) {
+    return (
+      <div className="bg-dark-800 border border-dark-700 rounded-xl">
+        <div className="p-6 border-b border-dark-700">
+          <h3 className="text-lg font-semibold">Sector Sentiment</h3>
+        </div>
+        <div className="p-6 flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+        </div>
+      </div>
+    );
+  }
+
+  const gaugePercent = ((data.gauge + 1) / 2) * 100;
+  const chartData = [
+    { name: "Weekly", value: data.expiry.weekly },
+    { name: "0DTE", value: data.expiry.zero_dte },
+  ];
+
+  return (
+    <div className="bg-dark-800 border border-dark-700 rounded-xl">
+      <div className="p-6 border-b border-dark-700">
+        <h3 className="text-lg font-semibold">Sector Sentiment</h3>
+      </div>
+      <div className="p-6 space-y-4">
+        <div className="flex items-center space-x-2">
+          {data.trend === "rising" ? (
+            <ArrowUp className="h-4 w-4 text-green-400" />
+          ) : (
+            <ArrowDown className="h-4 w-4 text-red-400" />
+          )}
+          <span className="text-sm text-dark-400">
+            {data.trend === "rising" ? "Net call premium rising" : "Net call premium falling"}
+          </span>
+        </div>
+        <Progress value={gaugePercent} />
+        <ChartContainer
+          config={{ value: { label: "Net Premium", color: "hsl(var(--chart-1))" } }}
+          className="h-40"
+        >
+          <BarChart data={chartData}>
+            <XAxis dataKey="name" />
+            <ChartTooltip content={<ChartTooltipContent />} />
+            <Bar dataKey="value" fill="var(--color-value)" />
+          </BarChart>
+        </ChartContainer>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -5,6 +5,7 @@ import Sidebar from "@/components/Sidebar";
 import MetricCard from "@/components/MetricCard";
 import AISignalsPanel from "@/components/AISignalsPanel";
 import OptionsFlowPanel from "@/components/OptionsFlowPanel";
+import SectorSentimentPanel from "@/components/SectorSentimentPanel";
 import TradingViewChart from "@/components/TradingViewChart";
 import ActivePositions from "@/components/ActivePositions";
 import RiskManagement from "@/components/RiskManagement";
@@ -92,10 +93,11 @@ export default function Dashboard() {
             />
           </div>
 
-          {/* Second Row: AI Signals and Options Flow */}
-          <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+          {/* Second Row: AI Signals, Options Flow, Sector Sentiment */}
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
             <AISignalsPanel />
             <OptionsFlowPanel />
+            <SectorSentimentPanel />
           </div>
 
           {/* Third Row: Charts and Positions */}

--- a/server/routes/sentimentRoutes.ts
+++ b/server/routes/sentimentRoutes.ts
@@ -89,6 +89,20 @@ router.get('/sector/:sector', async (req, res) => {
   }
 });
 
+// Get sector/ETF tide and net flow expiry sentiment
+router.get('/sector/:sector/tide-expiry', async (req, res) => {
+  try {
+    const data = await sentimentAnalysisService.getSectorTideExpirySentiment(req.params.sector);
+    res.json(data);
+  } catch (error) {
+    console.error('Error fetching sector tide expiry sentiment:', error);
+    res.status(500).json({
+      error: 'Failed to fetch sector tide expiry sentiment',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
+
 // Get sentiment for all watchlist tickers
 router.get('/watchlist', async (_req, res) => {
   try {


### PR DESCRIPTION
## Summary
- compute sector or ETF sentiment by combining tide data and net flow by expiry
- expose new `/api/sentiment/sector/:sector/tide-expiry` endpoint
- add dashboard panel showing gauge for net call premium trend and weekly vs 0DTE flow

## Testing
- `npm test` *(fails: Missing script "test"*)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689029ae4e408320bcadf19f9def6fa7