### PR TITLE
Add afterhours earnings stats and GUI table

### DIFF
--- a/client/src/pages/earnings-dashboard.tsx
+++ b/client/src/pages/earnings-dashboard.tsx
@@ -14,6 +14,26 @@ interface Candidate {
   atmIV: number;
 }
 
+interface EarningsRecord {
+  ticker: string;
+  report_date: string;
+  report_time: string;
+  actual_eps: number;
+  expected_move: number;
+  expected_move_perc: number;
+  pre_earnings_close: number;
+  post_earnings_close: number;
+  reaction: number;
+  sector: string;
+  marketcap: number;
+  is_sp500: boolean;
+  median_move_1d: number | null;
+  q1_move_1d: number | null;
+  q3_move_1d: number | null;
+  long_straddle_median_1d: number | null;
+  short_straddle_median_1d: number | null;
+}
+
 interface ScreenerResponse {
   candidates: Candidate[];
 }
@@ -26,6 +46,10 @@ export default function EarningsDashboardPage() {
   });
 
   const [gex, setGex] = useState<Record<string, number>>({});
+
+  const { data: earnings } = useQuery<{ data: EarningsRecord[] }>({
+    queryKey: ['/api/earnings/latest'],
+  });
 
   async function fetchGex() {
     if (!data?.candidates) return;
@@ -53,8 +77,96 @@ export default function EarningsDashboardPage() {
   const rows =
     data?.candidates.filter((c) => new Date(c.earningsDate) > new Date()) || [];
 
+  function expectedMoveClass(row: EarningsRecord) {
+    if (row.q1_move_1d == null || row.q3_move_1d == null) return '';
+    if (row.expected_move_perc > row.q3_move_1d) return 'text-red-600';
+    if (row.expected_move_perc < row.q1_move_1d) return 'text-green-600';
+    return 'text-yellow-600';
+  }
+
   return (
     <div className="p-6 space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Earnings Results</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Ticker</TableHead>
+                <TableHead>Sector</TableHead>
+                <TableHead className="text-right">Market Cap</TableHead>
+                <TableHead className="text-center">S&P 500</TableHead>
+                <TableHead>Report Time</TableHead>
+                <TableHead className="text-right">Actual EPS</TableHead>
+                <TableHead className="text-right">Exp Move $</TableHead>
+                <TableHead className="text-right">Exp Move %</TableHead>
+                <TableHead className="text-right">Pre Close</TableHead>
+                <TableHead className="text-right">Post Close</TableHead>
+                <TableHead className="text-right">Reaction %</TableHead>
+                <TableHead className="text-right">Hist Median Move%</TableHead>
+                <TableHead className="text-right">Long Straddle 1d</TableHead>
+                <TableHead className="text-right">Short Straddle 1d</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {earnings?.data.map((r) => (
+                <TableRow key={`${r.ticker}-${r.report_date}`}>
+                  <TableCell className="font-medium">{r.ticker}</TableCell>
+                  <TableCell>{r.sector}</TableCell>
+                  <TableCell className="text-right">
+                    {r.marketcap.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    {r.is_sp500 ? 'Yes' : 'No'}
+                  </TableCell>
+                  <TableCell>{r.report_time}</TableCell>
+                  <TableCell className="text-right">
+                    {r.actual_eps?.toFixed(2)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {r.expected_move?.toFixed(2)}
+                  </TableCell>
+                  <TableCell className={`text-right ${expectedMoveClass(r)}`}>
+                    {(r.expected_move_perc * 100).toFixed(2)}%
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {r.pre_earnings_close?.toFixed(2)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {r.post_earnings_close?.toFixed(2)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {(r.reaction * 100).toFixed(2)}%
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {r.median_move_1d != null
+                      ? (r.median_move_1d * 100).toFixed(2)
+                      : 'N/A'}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {r.long_straddle_median_1d != null
+                      ? r.long_straddle_median_1d.toFixed(4)
+                      : 'N/A'}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {r.short_straddle_median_1d != null
+                      ? r.short_straddle_median_1d.toFixed(4)
+                      : 'N/A'}
+                  </TableCell>
+                </TableRow>
+              )) || (
+                <TableRow>
+                  <TableCell colSpan={14} className="text-center">
+                    No data
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
       <Card>
         <CardHeader>
           <CardTitle>Upcoming Earnings Opportunities</CardTitle>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,6 +9,7 @@ import ordersRoutes from "./routes/orders";
 import fdaRoutes from "./routes/fdaRoutes";
 import optionsScreenerRoutes from "./routes/optionsScreener";
 import earningsScreenerRoutes from "./routes/earningsScreener";
+import earningsStatsRoutes from "./routes/earningsStats";
 import { 
   insertTradingSignalSchema, 
   insertPositionSchema,
@@ -2604,6 +2605,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Initialize routes last
   app.use('/api/options', optionsScreenerRoutes);
   app.use('/api/options', earningsScreenerRoutes);
+  app.use('/api/earnings', earningsStatsRoutes);
   
   // Options heatmap routes
   const { default: optionsHeatmapRoutes } = await import('./routes/optionsHeatmap');

--- a/server/routes/earningsStats.ts
+++ b/server/routes/earningsStats.ts
@@ -1,0 +1,83 @@
+import { Router } from 'express';
+import { UnusualWhalesService } from '../services/unusualWhales';
+
+const router = Router();
+const uw = new UnusualWhalesService();
+
+function median(values: number[]): number | null {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function quantile(values: number[], q: number): number | null {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const pos = (sorted.length - 1) * q;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  if (sorted[base + 1] !== undefined) {
+    return sorted[base] + rest * (sorted[base + 1] - sorted[base]);
+  }
+  return sorted[base];
+}
+
+router.get('/latest', async (req, res) => {
+  const date = typeof req.query.date === 'string' ? req.query.date : undefined;
+  try {
+    const [afterhours, premarket] = await Promise.all([
+      uw.getEarningsAfterhours({ date }),
+      uw.getEarningsPremarket({ date }),
+    ]);
+
+    const combined = [
+      ...afterhours.map((r: any) => ({ ...r, report_time: r.report_time || 'postmarket' })),
+      ...premarket.map((r: any) => ({ ...r, report_time: r.report_time || 'premarket' })),
+    ];
+
+    const results: any[] = [];
+    for (const item of combined) {
+      const ticker = item.symbol;
+      const history = await uw.getHistoricalEarnings(ticker);
+      const moves = history
+        .map((h: any) => parseFloat(h.post_earnings_move_1d))
+        .filter((n: number) => Number.isFinite(n));
+      const longStr = history
+        .map((h: any) => parseFloat(h.long_straddle_1d))
+        .filter((n: number) => Number.isFinite(n));
+      const shortStr = history
+        .map((h: any) => parseFloat(h.short_straddle_1d))
+        .filter((n: number) => Number.isFinite(n));
+
+      results.push({
+        ticker,
+        report_date: item.report_date,
+        report_time: item.report_time,
+        actual_eps: parseFloat(item.actual_eps),
+        expected_move: parseFloat(item.expected_move),
+        expected_move_perc: parseFloat(item.expected_move_perc),
+        pre_earnings_close: parseFloat(item.pre_earnings_close),
+        post_earnings_close: parseFloat(item.post_earnings_close),
+        reaction: parseFloat(item.reaction),
+        sector: item.sector,
+        marketcap: parseFloat(item.marketcap),
+        is_sp500: item.is_s_p_500,
+        median_move_1d: median(moves),
+        q1_move_1d: quantile(moves, 0.25),
+        q3_move_1d: quantile(moves, 0.75),
+        long_straddle_median_1d: median(longStr),
+        short_straddle_median_1d: median(shortStr),
+      });
+    }
+
+    res.json({ data: results });
+  } catch (err) {
+    console.error('Failed to fetch earnings stats', err);
+    res.status(500).json({ error: 'Failed to fetch earnings stats' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add `/api/earnings/latest` endpoint combining afterhours & premarket data with historical move and straddle stats
- display recent earnings results on dashboard with sector, marketcap, S&P500 flags and color-coded expected moves

## Testing
- `npm run check`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68902ad360c48320944a8af1385199ec