### PR TITLE
feat: enhance market sentiment metrics

### DIFF
--- a/FEATURES_OVERVIEW.md
+++ b/FEATURES_OVERVIEW.md
@@ -73,6 +73,10 @@
 - Commodities tracking (gold and oil prices)
 - Trump communications impact assessment
 - News flow sentiment scoring
+- Options volume and market tide metrics (call-to-put premium ratio)
+- Open-interest change monitoring with watchlist filtering
+- Economic and FDA calendars with sentiment-scored news headlines
+- SPiKE volatility index and correlation metrics for risk management
 
 **Business Value**: Provides comprehensive market sentiment context for better trade timing
 

--- a/server/services/unusualWhales.ts
+++ b/server/services/unusualWhales.ts
@@ -753,6 +753,47 @@ export class UnusualWhalesService {
     }
   }
 
+  async getEconomicCalendar(params: { tickers?: string[]; start_date?: string; end_date?: string } = {}): Promise<any> {
+    try {
+      const search = new URLSearchParams();
+      params.tickers?.forEach(t => search.append('tickers', t));
+      if (params.start_date) search.append('start_date', params.start_date);
+      if (params.end_date) search.append('end_date', params.end_date);
+      const endpoint = `/calendar/economic${search.toString() ? `?${search.toString()}` : ''}`;
+      return await this.makeRequest<any>(endpoint);
+    } catch (error) {
+      console.error('Failed to fetch economic calendar:', error);
+      return null;
+    }
+  }
+
+  async getFdaCalendar(params: { tickers?: string[]; start_date?: string; end_date?: string } = {}): Promise<any> {
+    try {
+      const search = new URLSearchParams();
+      params.tickers?.forEach(t => search.append('tickers', t));
+      if (params.start_date) search.append('start_date', params.start_date);
+      if (params.end_date) search.append('end_date', params.end_date);
+      const endpoint = `/calendar/fda${search.toString() ? `?${search.toString()}` : ''}`;
+      return await this.makeRequest<any>(endpoint);
+    } catch (error) {
+      console.error('Failed to fetch FDA calendar:', error);
+      return null;
+    }
+  }
+
+  async getNewsHeadlines(params: { tickers?: string[]; limit?: number } = {}): Promise<any> {
+    try {
+      const search = new URLSearchParams();
+      params.tickers?.forEach(t => search.append('tickers', t));
+      if (params.limit) search.append('limit', params.limit.toString());
+      const endpoint = `/news/headlines${search.toString() ? `?${search.toString()}` : ''}`;
+      return await this.makeRequest<any>(endpoint);
+    } catch (error) {
+      console.error('Failed to fetch news headlines:', error);
+      return null;
+    }
+  }
+
   // Watchlist helpers
 
   async getWatchlistDarkpool(tickers: string[], filters: Parameters<UnusualWhalesService['getDarkpoolForTicker']>[1] = {}) {


### PR DESCRIPTION
## Summary
- extend UnusualWhales service with economic calendar, FDA calendar, and news headline endpoints
- compute call-to-put premium ratio, filter OI changes by watchlist, and integrate correlations and macro events in market sentiment service
- document new sentiment data sources including options volume, calendars, and SPiKE correlations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68902bee1dc88320ac23a0678df2c040