### PR TITLE
feat: expose additional unusual whales data

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,6 +40,7 @@ import WhaleScoreHeatMapPage from "@/pages/whale-score-heatmap";
 import SentimentFlowOverlayPage from "@/pages/sentiment-flow-overlay";
 import NotFound from "@/pages/not-found";
 import EarningsDashboardPage from "@/pages/earnings-dashboard";
+import UnusualWhalesDashboardPage from "@/pages/unusual-whales-dashboard";
 
 function Router() {
   return (
@@ -78,6 +79,7 @@ function Router() {
       <Route path="/whale-score-heatmap" component={WhaleScoreHeatMapPage} />
       <Route path="/sentiment-flow-overlay" component={SentimentFlowOverlayPage} />
       <Route path="/earnings" component={EarningsDashboardPage} />
+      <Route path="/uw-data" component={UnusualWhalesDashboardPage} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -13,6 +13,7 @@ const navigationItems = [
   { href: "/machine-learning", label: "ML Engine", icon: "fas fa-cogs" },
   { href: "/macro", label: "Macro Dashboard", icon: "fas fa-globe" },
   { href: "/watchlist", label: "Watchlist & Intelligence", icon: "fas fa-list-alt" },
+  { href: "/uw-data", label: "Unusual Whales Data", icon: "fas fa-fish" },
   { href: "/earnings", label: "Earnings Dashboard", icon: "fas fa-bullhorn" },
   { href: "/flow", label: "Options Flow", icon: "fas fa-water" },
   { href: "/options-screener", label: "Options Screener", icon: "fas fa-search" },

--- a/client/src/pages/unusual-whales-dashboard.tsx
+++ b/client/src/pages/unusual-whales-dashboard.tsx
@@ -1,0 +1,59 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function UnusualWhalesDashboardPage() {
+  const { data: oiDelta } = useQuery<any>({ queryKey: ['/api/unusual-whales/open-interest-delta'] });
+  const { data: darkPool } = useQuery<any>({ queryKey: ['/api/unusual-whales/dark-pool-scans'] });
+  const { data: multileg } = useQuery<any>({ queryKey: ['/api/unusual-whales/multileg'] });
+  const { data: sectorRotation } = useQuery<any>({ queryKey: ['/api/unusual-whales/sector-rotation'] });
+  const { data: volStats } = useQuery<any>({ queryKey: ['/api/unusual-whales/volatility/stats', 'SPY'] });
+  const { data: volTerm } = useQuery<any>({ queryKey: ['/api/unusual-whales/volatility/term-structure', 'SPY'] });
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <h1 className="text-3xl font-bold">Unusual Whales Data</h1>
+
+      <Card>
+        <CardHeader><CardTitle>Open Interest Delta</CardTitle></CardHeader>
+        <CardContent>
+          <pre className="overflow-auto text-xs">{JSON.stringify(oiDelta, null, 2)}</pre>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle>Dark Pool Scans</CardTitle></CardHeader>
+        <CardContent>
+          <pre className="overflow-auto text-xs">{JSON.stringify(darkPool, null, 2)}</pre>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle>Multileg Strategies</CardTitle></CardHeader>
+        <CardContent>
+          <pre className="overflow-auto text-xs">{JSON.stringify(multileg, null, 2)}</pre>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle>Sector Rotation</CardTitle></CardHeader>
+        <CardContent>
+          <pre className="overflow-auto text-xs">{JSON.stringify(sectorRotation, null, 2)}</pre>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle>Volatility Stats (SPY)</CardTitle></CardHeader>
+        <CardContent>
+          <pre className="overflow-auto text-xs">{JSON.stringify(volStats, null, 2)}</pre>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle>Volatility Term Structure (SPY)</CardTitle></CardHeader>
+        <CardContent>
+          <pre className="overflow-auto text-xs">{JSON.stringify(volTerm, null, 2)}</pre>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -547,6 +547,26 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/unusual-whales/volatility/stats/:symbol", async (req, res) => {
+    try {
+      const data = await uwService.getVolatilityStats(req.params.symbol.toUpperCase());
+      res.json(data);
+    } catch (error) {
+      console.error(`Failed to fetch volatility stats for ${req.params.symbol}:`, error);
+      res.status(500).json({ message: "Failed to fetch volatility stats" });
+    }
+  });
+
+  app.get("/api/unusual-whales/volatility/term-structure/:symbol", async (req, res) => {
+    try {
+      const data = await uwService.getVolatilityTermStructure(req.params.symbol.toUpperCase());
+      res.json(data);
+    } catch (error) {
+      console.error(`Failed to fetch volatility term structure for ${req.params.symbol}:`, error);
+      res.status(500).json({ message: "Failed to fetch volatility term structure" });
+    }
+  });
+
   // LEAP Analysis endpoints
   // Accept optional stringency level as path parameter to match client query structure
   app.get("/api/leaps/analyze/:level?", async (req, res) => {

--- a/server/services/unusualWhales.ts
+++ b/server/services/unusualWhales.ts
@@ -820,6 +820,26 @@ export class UnusualWhalesService {
     }
   }
 
+  async getVolatilityStats(ticker: string): Promise<any> {
+    try {
+      const data = await this.makeRequest<{ data: any }>(`/stock/${ticker}/volatility/stats`);
+      return data.data || null;
+    } catch (error) {
+      console.error(`Failed to fetch volatility stats for ${ticker}:`, error);
+      return null;
+    }
+  }
+
+  async getVolatilityTermStructure(ticker: string): Promise<any[]> {
+    try {
+      const data = await this.makeRequest<{ data: any[] }>(`/stock/${ticker}/volatility/term-structure`);
+      return data.data || [];
+    } catch (error) {
+      console.error(`Failed to fetch volatility term structure for ${ticker}:`, error);
+      return [];
+    }
+  }
+
   async getStockData(ticker: string): Promise<any> {
     try {
       const [state, greeks, oiStrike, oiExpiry, maxPain, netPrem, news] = await Promise.allSettled([


### PR DESCRIPTION
## Summary
- expose volatility stats and term structure from Unusual Whales service
- add Unusual Whales dashboard page for OI delta, dark pool scans, multileg strategies, sector rotation and volatility
- wire dashboard into sidebar and client routing

## Testing
- `npm run check`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68910f79a9e88320befc9a8dd70d2258